### PR TITLE
feature: add local workflow installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         run: npm run format:check
         continue-on-error: true
       
-      - name: Run tests
-        run: npm run test:run
-      
       - name: Build
         run: npm run build
+
+      - name: Run tests
+        run: npm run test:run
       
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -449,8 +449,8 @@ npm run serve
 ## Test
 
 ```bash
-npm test -- --run
 npm run build
+npm test -- --run
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -315,15 +315,114 @@ Known limitations:
 
 ---
 
-## Run
+## Install from npm
 
-Quickest way to try the editor (no clone, serves the built app):
+Use the public `motionly` package from the npm registry. You do not need to clone this repository or download a tarball. Motionly requires Node.js `20.19.0` or newer.
+
+```bash
+npx motionly init demo
+```
+
+For the easiest project setup:
+
+1. Enter `2` to install the skills inside the new project.
+2. Enter `1` to install them for all supported agents.
+
+The complete terminal session looks like this:
+
+```text
+$ npx motionly init demo
+Created /path/to/workspace/demo
+
+Install Motionly agent skills?
+  1. Skip
+  2. Project — inside the new project
+  3. Global — every project for this user
+Select [1]: 2
+
+Which agents should receive the Motionly skill?
+  1. All supported agents
+  2. Claude Code
+  3. Codex
+  4. Gemini CLI
+  5. Kiro CLI
+Select [1]: 1
+
+Added claude: /path/to/workspace/demo/.claude/skills/motionly/SKILL.md
+Added codex: /path/to/workspace/demo/.agents/skills/motionly/SKILL.md
+Added gemini: /path/to/workspace/demo/.gemini/skills/motionly/SKILL.md
+Added kiro: /path/to/workspace/demo/.kiro/skills/motionly/SKILL.md
+
+  To reopen later: cd demo && npx motionly dev
+
+  Motionly is running.
+  Open this URL in your browser: http://localhost:4173/editor
+  Project: /path/to/workspace/demo
+  Press Ctrl+C to stop.
+```
+
+Open `http://localhost:4173/editor` in your browser. Keep the terminal running while you edit and
+press `Ctrl+C` when finished.
+
+Other wizard choices:
+
+- Choose **Skip** to create the project without agent skills.
+- Choose **Global** to make the selected skills available to every project for your user.
+- Choose one agent instead of **All supported agents** if you only use that agent.
+
+To install skills without creating a project:
+
+```bash
+motionly skills add
+```
+
+For scripts and CI, skip the wizard with flags:
+
+```bash
+motionly skills add --all --scope project
+motionly skills add --provider codex --scope global
+```
+
+Supported provider names are `claude`, `codex`, `gemini`, and `kiro`.
+
+### 3. Project layout
+
+The project contains:
+
+```text
+demo/
+├── AGENTS.md
+├── assets/
+├── project.motion
+├── meta.json
+└── README.md
+```
+
+### 4. Reopen the project later
+
+```bash
+cd demo
+motionly dev
+```
+
+Motionly opens `http://localhost:4173/editor`, loads `project.motion`, serves files from `assets/`, and saves editor changes back to the project. Use `--port <n>` to change the port or `--no-open` to skip opening the browser.
+
+### Run without a global installation
+
+You can use the public package directly through `npx` instead:
+
+```bash
+npx motionly --help
+npx motionly init my-video
+```
+
+For the no-setup browser editor:
 
 ```bash
 npx motionly
 ```
 
-This opens the editor at `http://localhost:4173`. Use `--port <n>` to change the port or `--no-open` to skip launching the browser.
+## Development from source
 
 For local development from source:
 
@@ -355,6 +454,7 @@ npm run build
 ```
 
 ---
+
 
 ## Contributing
 

--- a/bin/motionly.js
+++ b/bin/motionly.js
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
-// Motionly launcher: `npx motionly` serves the built editor locally.
-// Zero dependencies — uses only Node's standard library.
+// Zero-dependency Motionly CLI and local editor server.
 
 import { createServer } from 'node:http';
-import { readFile, stat } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
-import { dirname, join, normalize, extname } from 'node:path';
+import { createInterface } from 'node:readline/promises';
 import { spawn } from 'node:child_process';
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { basename, dirname, extname, join, normalize, resolve, sep } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = normalize(join(here, '..'));
 const dist = join(root, 'dist');
+const skillTemplatePath = join(root, 'templates', 'motionly-skill', 'SKILL.md');
+const projectTemplateRoot = join(root, 'templates', 'project');
+
+const PROVIDERS = {
+  claude: '.claude/skills/motionly/SKILL.md',
+  codex: '.agents/skills/motionly/SKILL.md',
+  gemini: '.gemini/skills/motionly/SKILL.md',
+  kiro: '.kiro/skills/motionly/SKILL.md',
+};
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -18,6 +28,7 @@ const MIME = {
   '.mjs': 'text/javascript; charset=utf-8',
   '.css': 'text/css; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
+  '.motion': 'text/plain; charset=utf-8',
   '.svg': 'image/svg+xml',
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -29,7 +40,9 @@ const MIME = {
   '.woff2': 'font/woff2',
   '.mp4': 'video/mp4',
   '.webm': 'video/webm',
+  '.m4v': 'video/x-m4v',
   '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
   '.map': 'application/json; charset=utf-8',
 };
 
@@ -40,76 +53,359 @@ function parsePort(argv) {
   return Number.isFinite(env) && env > 0 ? env : 4173;
 }
 
-async function ensureBuilt() {
+function optionValues(argv, name) {
+  return argv.flatMap((arg, index) => (arg === name && argv[index + 1] ? [argv[index + 1]] : []));
+}
+
+function firstPositional(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--port' || argv[index] === '-p') {
+      index += 1;
+    } else if (!argv[index].startsWith('-')) {
+      return argv[index];
+    }
+  }
+  return undefined;
+}
+
+async function exists(path) {
   try {
-    await stat(join(dist, 'index.html'));
+    await stat(path);
     return true;
   } catch {
-    console.error(
-      '\nMotionly is not built yet.\n' +
-        'Run "npm run build" in the project, or use the published package which ships the build.\n'
-    );
     return false;
   }
 }
 
+async function ensureBuilt() {
+  if (await exists(join(dist, 'index.html'))) return true;
+  console.error(
+    '\nMotionly is not built yet.\n' +
+      'Run "npm run build" in the project, or use the published package which ships the build.\n'
+  );
+  return false;
+}
+
 function openBrowser(url) {
-  const platform = process.platform;
   const command =
-    platform === 'darwin' ? 'open' : platform === 'win32' ? 'cmd' : 'xdg-open';
-  const args = platform === 'win32' ? ['/c', 'start', '', url] : [url];
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
   try {
     spawn(command, args, { stdio: 'ignore', detached: true }).unref();
   } catch {
-    /* opening the browser is best-effort */
+    // Opening the browser is best-effort.
   }
 }
 
-async function main() {
-  if (!(await ensureBuilt())) process.exit(1);
-  const port = parsePort(process.argv.slice(2));
-  const noOpen = process.argv.includes('--no-open');
+async function installSkills(base, providers) {
+  const unknown = providers.find((provider) => !PROVIDERS[provider]);
+  if (unknown)
+    throw new Error(`Unknown provider "${unknown}". Use: ${Object.keys(PROVIDERS).join(', ')}`);
+
+  const source = await readFile(skillTemplatePath, 'utf8');
+  for (const provider of providers) {
+    const relative = PROVIDERS[provider];
+    const target = join(base, relative);
+    await mkdir(dirname(target), { recursive: true });
+    try {
+      await writeFile(target, source, { encoding: 'utf8', flag: 'wx' });
+      console.log(`Added ${provider}: ${target}`);
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      console.log(`Kept ${provider}: ${target} already exists`);
+    }
+  }
+}
+
+async function choose(terminal, question, options) {
+  console.log(`\n${question}`);
+  options.forEach((option, index) => console.log(`  ${index + 1}. ${option.label}`));
+
+  while (true) {
+    const answer = (await terminal.question('Select [1]: ')).trim() || '1';
+    const index = Number(answer) - 1;
+    if (Number.isInteger(index) && options[index]) return options[index].value;
+    console.log(`Choose a number from 1 to ${options.length}.`);
+  }
+}
+
+async function selectSkillOptions(terminal, providers, scope) {
+  const selectedScope =
+    scope ??
+    (await choose(terminal, 'Where should Motionly install the skill?', [
+      { label: 'Project — this project only', value: 'project' },
+      { label: 'Global — every project for this user', value: 'global' },
+    ]));
+
+  let selectedProviders = providers;
+  if (!selectedProviders.length) {
+    const provider = await choose(terminal, 'Which agents should receive the Motionly skill?', [
+      { label: 'All supported agents', value: 'all' },
+      { label: 'Claude Code', value: 'claude' },
+      { label: 'Codex', value: 'codex' },
+      { label: 'Gemini CLI', value: 'gemini' },
+      { label: 'Kiro CLI', value: 'kiro' },
+    ]);
+    selectedProviders = provider === 'all' ? Object.keys(PROVIDERS) : [provider];
+  }
+
+  return { providers: [...new Set(selectedProviders)], scope: selectedScope };
+}
+
+function skillBase(scope, projectBase) {
+  return scope === 'global' ? homedir() : projectBase;
+}
+
+function parseSkillOptions(argv) {
+  const scopes = optionValues(argv, '--scope');
+  if (scopes.length > 1) throw new Error('Choose only one --scope.');
+  const scope = scopes[0];
+  if (scope && scope !== 'project' && scope !== 'global')
+    throw new Error('Scope must be "project" or "global".');
+
+  const providers = argv.includes('--all')
+    ? Object.keys(PROVIDERS)
+    : optionValues(argv, '--provider');
+  return { providers, scope };
+}
+
+async function resolveSkillOptions(argv) {
+  let options = parseSkillOptions(argv);
+  if (
+    process.stdin.isTTY &&
+    process.stdout.isTTY &&
+    (!options.scope || !options.providers.length)
+  ) {
+    console.log('\nMotionly skill setup');
+    const terminal = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      options = await selectSkillOptions(terminal, options.providers, options.scope);
+    } finally {
+      terminal.close();
+    }
+  } else {
+    options.scope ??= 'project';
+  }
+
+  if (!options.providers.length)
+    throw new Error(
+      'Choose --provider <name> or --all. Add --scope project|global to choose where.'
+    );
+  return options;
+}
+
+async function promptForSkills(target) {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+
+  const terminal = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const scope = await choose(terminal, 'Install Motionly agent skills?', [
+      { label: 'Skip', value: 'skip' },
+      { label: 'Project — inside the new project', value: 'project' },
+      { label: 'Global — every project for this user', value: 'global' },
+    ]);
+    if (scope === 'skip') return;
+    const options = await selectSkillOptions(terminal, [], scope);
+    await installSkills(skillBase(options.scope, target), options.providers);
+  } finally {
+    terminal.close();
+  }
+}
+
+async function initProject(name, argv = []) {
+  if (!name || name.startsWith('-')) throw new Error('Usage: npx motionly init <project-folder>');
+  const target = resolve(name);
+  if (await exists(target)) {
+    if ((await readdir(target)).length) throw new Error(`Folder is not empty: ${target}`);
+  } else {
+    await mkdir(target, { recursive: true });
+  }
+
+  const created = new Date().toISOString();
+  const replacements = { '{{name}}': basename(target), '{{created}}': created };
+  for (const filename of ['AGENTS.md', 'project.motion', 'meta.json', 'README.md']) {
+    let content = await readFile(join(projectTemplateRoot, filename), 'utf8');
+    for (const [token, value] of Object.entries(replacements))
+      content = content.replaceAll(token, value);
+    await writeFile(join(target, filename), content, { encoding: 'utf8', flag: 'wx' });
+  }
+  await mkdir(join(target, 'assets'));
+  console.log(`Created ${target}`);
+  await promptForSkills(target);
+  if (process.stdin.isTTY && process.stdout.isTTY) {
+    console.log(`\n  To reopen later: cd ${name} && npx motionly dev`);
+    await serveEditor(argv, target);
+  }
+}
+
+async function readRequestBody(request, maximum = 5_000_000) {
+  let source = '';
+  for await (const chunk of request) {
+    source += chunk;
+    if (source.length > maximum) throw new Error('TOO_LARGE');
+  }
+  return source;
+}
+
+function safeFile(rootPath, pathname) {
+  const filePath = normalize(join(rootPath, pathname));
+  return filePath === rootPath || filePath.startsWith(`${rootPath}${sep}`) ? filePath : null;
+}
+
+async function serveFile(response, filePath, method = 'GET') {
+  const info = await stat(filePath);
+  if (!info.isFile()) throw new Error('NOT_FOUND');
+  response.writeHead(200, {
+    'Content-Type': MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream',
+    'Content-Length': info.size,
+  });
+  response.end(method === 'HEAD' ? undefined : await readFile(filePath));
+}
+
+async function serveEditor(argv, projectFolder = null) {
+  if (!(await ensureBuilt())) process.exitCode = 1;
+  if (process.exitCode) return;
+
+  const projectRoot = projectFolder ? resolve(projectFolder) : null;
+  const projectPath = projectRoot ? join(projectRoot, 'project.motion') : null;
+  const assetsRoot = projectRoot ? join(projectRoot, 'assets') : null;
+  if (projectPath && !(await exists(projectPath))) throw new Error(`Missing ${projectPath}`);
+  if (assetsRoot && !(await exists(assetsRoot))) throw new Error(`Missing ${assetsRoot}`);
+
+  const port = parsePort(argv);
+  if (!Number.isFinite(port) || port < 1 || port > 65535)
+    throw new Error('Port must be between 1 and 65535.');
+  const noOpen = argv.includes('--no-open');
 
   const server = createServer(async (request, response) => {
     try {
       const url = new URL(request.url ?? '/', 'http://localhost');
-      let pathname = decodeURIComponent(url.pathname);
-      if (pathname.endsWith('/')) pathname += 'index.html';
-      // Resolve within dist and block path traversal.
-      const filePath = normalize(join(dist, pathname));
-      if (!filePath.startsWith(dist)) {
+      const pathname = decodeURIComponent(url.pathname);
+
+      if (projectPath && pathname === '/api/motion-project') {
+        if (request.method === 'GET' || request.method === 'HEAD') {
+          const source = await readFile(projectPath);
+          response.writeHead(200, {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Content-Length': source.length,
+            'X-Motionly-Project-Name': basename(projectPath),
+            'Cache-Control': 'no-store',
+          });
+          response.end(request.method === 'HEAD' ? undefined : source);
+          return;
+        }
+        if (request.method === 'PUT') {
+          const source = await readRequestBody(request);
+          if (!source.includes('canvas {')) {
+            response.writeHead(400).end('Invalid .motion project');
+            return;
+          }
+          await writeFile(projectPath, source, 'utf8');
+          response.writeHead(204).end();
+          return;
+        }
+        response.writeHead(405, { Allow: 'GET, HEAD, PUT' }).end();
+        return;
+      }
+
+      if (pathname.startsWith('/assets/')) {
+        const bundledAsset = safeFile(dist, pathname.slice(1));
+        if (bundledAsset && (await exists(bundledAsset))) {
+          await serveFile(response, bundledAsset, request.method);
+          return;
+        }
+      }
+
+      if (assetsRoot && pathname.startsWith('/assets/')) {
+        const filePath = safeFile(assetsRoot, pathname.slice('/assets/'.length));
+        if (!filePath) {
+          response.writeHead(403).end('Forbidden');
+          return;
+        }
+        await serveFile(response, filePath, request.method);
+        return;
+      }
+
+      let relative = pathname.endsWith('/') ? `${pathname}index.html` : pathname;
+      let filePath = safeFile(dist, relative.replace(/^\/+/, ''));
+      if (!filePath) {
         response.writeHead(403).end('Forbidden');
         return;
       }
-      let body;
-      let resolved = filePath;
       try {
-        body = await readFile(resolved);
+        await serveFile(response, filePath, request.method);
       } catch {
-        // SPA fallback: serve index.html for unknown routes.
-        resolved = join(dist, 'index.html');
-        body = await readFile(resolved);
+        await serveFile(response, join(dist, 'index.html'), request.method);
       }
-      response.writeHead(200, { 'Content-Type': MIME[extname(resolved)] ?? 'application/octet-stream' });
-      response.end(body);
-    } catch {
-      response.writeHead(500).end('Internal Server Error');
+    } catch (error) {
+      const status =
+        error.message === 'TOO_LARGE' ? 413 : error.message === 'NOT_FOUND' ? 404 : 500;
+      response.writeHead(status).end(status === 500 ? 'Internal Server Error' : error.message);
     }
   });
 
   server.listen(port, () => {
-    const url = `http://localhost:${port}`;
-    console.log(`\n  Motionly is running at ${url}\n  Press Ctrl+C to stop.\n`);
+    const url = `http://localhost:${port}${projectRoot ? '/editor' : ''}`;
+    console.log(
+      `\n  Motionly is running.\n  Open this URL in your browser: ${url}${projectRoot ? `\n  Project: ${projectRoot}` : ''}\n  Press Ctrl+C to stop.\n`
+    );
     if (!noOpen) openBrowser(url);
   });
 
   server.on('error', (error) => {
     if (error.code === 'EADDRINUSE') {
-      console.error(`Port ${port} is in use. Try: npx motionly --port ${port + 1}`);
-      process.exit(1);
+      console.error(
+        `Port ${port} is in use. Try: npx motionly ${projectRoot ? 'dev ' : ''}--port ${port + 1}`
+      );
+      process.exitCode = 1;
+      return;
     }
     throw error;
   });
 }
 
-main();
+function printHelp() {
+  console.log(`Motionly
+
+  npx motionly                         Open the browser editor
+  npx motionly skills add              Pick project/global scope and agents
+  npx motionly skills add --provider <claude|codex|gemini|kiro>
+  npx motionly skills add --all
+  npx motionly init <project-folder>    Create and open a local project
+  npx motionly dev [project-folder]    Open and save a local project
+
+Options: --scope <project|global>, --port <number>, --no-open`);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const [command, subcommand] = argv;
+  if (command === 'skills') {
+    if (subcommand !== 'add')
+      throw new Error(
+        'Usage: npx motionly skills add [--provider <name> | --all] [--scope project|global]'
+      );
+    const options = await resolveSkillOptions(argv.slice(2));
+    await installSkills(skillBase(options.scope, process.cwd()), options.providers);
+    return;
+  }
+  if (command === 'init') {
+    await initProject(argv[1], argv.slice(2));
+    return;
+  }
+  if (command === 'dev') {
+    const folder = firstPositional(argv.slice(1)) ?? '.';
+    await serveEditor(argv.slice(1), folder);
+    return;
+  }
+  if (command === 'help' || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+  await serveEditor(argv);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -79,5 +79,6 @@ This runs the same launcher `npx motionly` uses against your local `dist/`.
 ## Test
 
 ```bash
+npm run build
 npm run test:run
 ```

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -15,6 +15,31 @@ npx motionly
 
 This serves the editor at `http://localhost:4173` and opens your browser. Use `--port <n>` to pick a port or `--no-open` to skip launching the browser.
 
+## Optional local project
+
+```bash
+npx motionly init my-video
+```
+
+The `init` wizard offers **Skip**, **Project**, and **Global** skill setup choices. If you install a
+skill, it then lets you choose all supported agents or one agent. After setup, Motionly starts the
+generated project automatically and tells you to open `http://localhost:4173/editor`.
+
+Press `Ctrl+C` to stop it. To reopen the project later:
+
+```bash
+cd my-video
+npx motionly dev
+```
+
+To install skills without creating a project, run `npx motionly skills add`. For a non-interactive
+install, use `--all --scope project` or `--provider codex --scope global`. Supported providers are
+`claude`, `codex`, `gemini`, and `kiro`.
+
+The local editor reads and saves `project.motion` and serves files from `assets/`. Asset imports are
+resolved by filename, so the same import works with local media or a browser upload. Motionly asks
+before replacing a filename match whose size or dimensions differ significantly.
+
 ## Requirements
 
 - Node.js `20.19.0` or newer
@@ -56,4 +81,3 @@ This runs the same launcher `npx motionly` uses against your local `dist/`.
 ```bash
 npm run test:run
 ```
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@coppsary/motionly",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coppsary/motionly",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/analytics": "2.0.1",
         "gsap": "^3.15.0",
         "lucide-svelte": "^1.0.1",
         "motion": "^12.42.2",
-        "motionly": "file:../../../../../tmp/motionly-1.0.0.tgz",
         "svelte": "^5.56.4",
         "svelvet": "^11.0.5"
       },
@@ -3643,26 +3642,6 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
       "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
-    },
-    "node_modules/motionly": {
-      "version": "1.0.0",
-      "resolved": "file:../../../../../tmp/motionly-1.0.0.tgz",
-      "integrity": "sha512-PccSDqj/s3l5V+fD51/bHysceza8INmHP1rq2VFNcXAfZBeayaZbcSX8qKxPpMDQ3UFypFIZYXkBlNxF3GsdJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@vercel/analytics": "2.0.1",
-        "gsap": "^3.15.0",
-        "lucide-svelte": "^1.0.1",
-        "motion": "^12.42.2",
-        "svelte": "^5.56.4",
-        "svelvet": "^11.0.5"
-      },
-      "bin": {
-        "motionly": "bin/motionly.js"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
     },
     "node_modules/mri": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "motionly",
+  "name": "@coppsary/motionly",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "motionly",
+      "name": "@coppsary/motionly",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -13,8 +13,12 @@
         "gsap": "^3.15.0",
         "lucide-svelte": "^1.0.1",
         "motion": "^12.42.2",
+        "motionly": "file:../../../../../tmp/motionly-1.0.0.tgz",
         "svelte": "^5.56.4",
         "svelvet": "^11.0.5"
+      },
+      "bin": {
+        "motionly": "bin/motionly.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -266,7 +270,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -315,7 +318,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1483,7 +1485,6 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1562,7 +1563,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1608,7 +1608,6 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -1989,7 +1988,6 @@
       "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
@@ -2026,7 +2024,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2523,7 +2520,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2583,7 +2579,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3286,7 +3281,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -3650,6 +3644,26 @@
       "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
+    "node_modules/motionly": {
+      "version": "1.0.0",
+      "resolved": "file:../../../../../tmp/motionly-1.0.0.tgz",
+      "integrity": "sha512-PccSDqj/s3l5V+fD51/bHysceza8INmHP1rq2VFNcXAfZBeayaZbcSX8qKxPpMDQ3UFypFIZYXkBlNxF3GsdJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/analytics": "2.0.1",
+        "gsap": "^3.15.0",
+        "lucide-svelte": "^1.0.1",
+        "motion": "^12.42.2",
+        "svelte": "^5.56.4",
+        "svelvet": "^11.0.5"
+      },
+      "bin": {
+        "motionly": "bin/motionly.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -3874,7 +3888,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3939,7 +3952,6 @@
       "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4354,7 +4366,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
       "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4622,7 +4633,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4677,7 +4687,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4796,7 +4805,6 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coppsary/motionly",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {
@@ -40,7 +40,6 @@
     "gsap": "^3.15.0",
     "lucide-svelte": "^1.0.1",
     "motion": "^12.42.2",
-    "motionly": "file:../../../../../tmp/motionly-1.0.0.tgz",
     "svelte": "^5.56.4",
     "svelvet": "^11.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "motionly",
+  "name": "@coppsary/motionly",
   "version": "1.0.0",
   "license": "Apache-2.0",
   "type": "module",
@@ -9,6 +9,7 @@
   "files": [
     "dist",
     "bin",
+    "templates",
     "README.md",
     "LICENSE"
   ],
@@ -39,6 +40,7 @@
     "gsap": "^3.15.0",
     "lucide-svelte": "^1.0.1",
     "motion": "^12.42.2",
+    "motionly": "file:../../../../../tmp/motionly-1.0.0.tgz",
     "svelte": "^5.56.4",
     "svelvet": "^11.0.5"
   },
@@ -70,5 +72,24 @@
     "*.{css,html}": [
       "prettier --write"
     ]
+  },
+  "description": "<div align=\"center\">   <img src=\"public/logo.svg\" alt=\"Motionly Logo\" width=\"100\">",
+  "main": "eslint.config.js",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/COPPSARY/Motionly.git"
+  },
+  "keywords": [],
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/COPPSARY/Motionly/issues"
+  },
+  "homepage": "https://github.com/COPPSARY/Motionly#readme",
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/src/ai/chat.ts
+++ b/src/ai/chat.ts
@@ -1,4 +1,5 @@
 import type { Asset } from '../types/scene';
+import { assetFilename } from '../assets/asset-resolution';
 
 export const AI_SETTINGS_KEY = 'motionly.ai.settings.v1';
 export const AI_HISTORY_KEY = 'motionly.ai.history.v1';
@@ -127,12 +128,22 @@ export function extractMotion(source: string): string | undefined {
 }
 
 export function maskEmbeddedAssetPaths(source: string, assets: Asset[]): string {
-  return replaceEmbeddedAssetPaths(source, assets, (asset) => `motionly-local:${asset.name}`);
+  return replaceEmbeddedAssetPaths(
+    source,
+    assets,
+    (asset) => `motionly-local:${encodeURIComponent(assetFilename(asset.path) || asset.name)}`
+  );
 }
 
 export function restoreEmbeddedAssetPaths(source: string, assets: Asset[]): string {
   for (const asset of assets.filter((item) => item.path.startsWith('data:'))) {
-    source = source.replaceAll(`"motionly-local:${asset.name}"`, `"${asset.path}"`);
+    const references = new Set([
+      asset.name,
+      encodeURIComponent(assetFilename(asset.path) || asset.name),
+    ]);
+    for (const reference of references) {
+      source = source.replaceAll(`"motionly-local:${reference}"`, `"${asset.path}"`);
+    }
   }
   return replaceEmbeddedAssetPaths(source, assets, (asset) => asset.path);
 }

--- a/src/assets/asset-loader.ts
+++ b/src/assets/asset-loader.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AssetType, EvaluatedScene, Scene } from '../types/scene';
+import { assetFilename } from './asset-resolution';
 
 export interface MotionlySvgData {
   width: number;
@@ -21,6 +22,7 @@ export interface MotionlySvgData {
 interface LoadedAssetMetadata {
   motionlySvg?: MotionlySvgData;
   motionlyDuration?: number;
+  motionlySize?: number;
 }
 
 export type LoadedImageAsset = HTMLImageElement &
@@ -43,10 +45,16 @@ export async function loadAssets(
   scene: Scene,
   baseUrl: string = document.baseURI
 ): Promise<Map<string, LoadedAsset>> {
+  const uploadedByFilename = new Map<string, string>();
+  for (const asset of scene.imports) {
+    const filename = assetFilename(asset.path);
+    if (asset.path.startsWith('data:') && filename) uploadedByFilename.set(filename, asset.path);
+  }
   const entries = await Promise.all(
     scene.imports.map(async (asset): Promise<[string, LoadedAsset] | null> => {
       try {
-        return [asset.name, await loadAsset(asset.path, baseUrl, asset.type)];
+        const path = uploadedByFilename.get(assetFilename(asset.path)) ?? asset.path;
+        return [asset.name, await loadAsset(path, baseUrl, asset.type)];
       } catch (error) {
         console.warn(`Could not load asset ${asset.path}:`, error);
         return null;
@@ -66,8 +74,23 @@ export async function loadAsset(
     path.startsWith('/') ? `${import.meta.env.BASE_URL}${path.slice(1)}` : path,
     baseUrl
   ).href;
-  if (type === 'video') return loadVideo(url);
-  return loadImage(url, type === 'svg');
+  const [asset, size] = await Promise.all([
+    type === 'video' ? loadVideo(url) : loadImage(url, type === 'svg'),
+    loadAssetSize(url),
+  ]);
+  if (size) asset.motionlySize = size;
+  return asset;
+}
+
+async function loadAssetSize(url: string): Promise<number | undefined> {
+  if (!/^https?:/i.test(url)) return undefined;
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    const size = Number(response.headers.get('content-length'));
+    return response.ok && Number.isFinite(size) && size > 0 ? size : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function loadImage(url: string, isSvg: boolean): Promise<LoadedAsset> {

--- a/src/assets/asset-resolution.ts
+++ b/src/assets/asset-resolution.ts
@@ -1,0 +1,43 @@
+export interface AssetIdentity {
+  width: number;
+  height: number;
+  size?: number;
+}
+
+/** Filename is the stable identity shared by local paths and browser uploads. */
+export function assetFilename(path: string): string {
+  const embeddedMarker = '#motionly-filename=';
+  const embeddedIndex = path.lastIndexOf(embeddedMarker);
+  if (embeddedIndex >= 0) return decode(path.slice(embeddedIndex + embeddedMarker.length));
+  if (path.startsWith('data:')) return '';
+  if (path.startsWith('motionly-local:')) {
+    return decode(path.slice('motionly-local:'.length).split(/[?#]/, 1)[0] ?? '');
+  }
+  const clean = path.split(/[?#]/, 1)[0] ?? path;
+  const filename = clean.split(/[\\/]/).pop() ?? '';
+  return decode(filename);
+}
+
+function decode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function tagEmbeddedAssetPath(dataUrl: string, filename: string): string {
+  return `${dataUrl.split('#', 1)[0]}#motionly-filename=${encodeURIComponent(filename)}`;
+}
+
+export function significantlyDifferentAsset(
+  existing: AssetIdentity,
+  replacement: AssetIdentity
+): boolean {
+  const ratio = (a: number, b: number) => Math.max(a, b) / Math.max(1, Math.min(a, b));
+  return (
+    ratio(existing.width, replacement.width) > 1.5 ||
+    ratio(existing.height, replacement.height) > 1.5 ||
+    (!!existing.size && !!replacement.size && ratio(existing.size, replacement.size) > 2)
+  );
+}

--- a/src/ui/MotionlyApp.svelte
+++ b/src/ui/MotionlyApp.svelte
@@ -78,12 +78,11 @@ animate title {
   $: if (fileHandle) scheduleAutoSave(motionCode);
 
   async function loadInitialProject() {
-    if (!import.meta.env.DEV) return;
     try {
       let response = await fetch('/api/motion-project', { cache: 'no-store' });
       if (response.ok && response.headers.get('content-type')?.startsWith('text/plain')) {
         motionCode = await response.text();
-        currentFile = 'motionly.motion';
+        currentFile = response.headers.get('x-motionly-project-name') || 'project.motion';
         serverBacked = true;
         return;
       }
@@ -128,7 +127,7 @@ animate title {
         headers: { 'content-type': 'text/plain;charset=utf-8' },
         body: motionCode,
       });
-      if (!response.ok) throw new Error(`Could not save motionly.motion (${response.status})`);
+      if (!response.ok) throw new Error(`Could not save ${currentFile} (${response.status})`);
       return;
     }
     const picker = (window as FilePickerWindow).showSaveFilePicker;

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -6,6 +6,8 @@
   import { evaluateScene } from '../../animation/evaluator';
   import { loadAssets, isLoadedVideo, pauseVideoAssets, synchronizeVideoAssets } from '../../assets/asset-loader';
   import type { LoadedAsset } from '../../assets/asset-loader';
+  import { assetFilename, significantlyDifferentAsset, tagEmbeddedAssetPath } from '../../assets/asset-resolution';
+  import type { AssetIdentity } from '../../assets/asset-resolution';
   import { CanvasRenderer, hiddenMaskSourceIds } from '../../render/canvas-renderer';
   import { canExport, exportVideo } from '../../export/exporter';
   import type { AnimationNode, AudioNode, CameraNode, ClipNode, ElementNode, ProgramNode, TrackNode } from '../../types/parser';
@@ -93,7 +95,8 @@
   let pendingPresetPath = '';
   let previewAsset: { src: string; width: number; height: number; type: 'image' | 'video' } | null = null;
   let videoRenderId = 0;
-  let draggingAsset: Element | null = null;
+  let isDraggingUpload = false;
+  let draggingAsset: Asset | null = null;
   let draggingTransition: 'crossfade' | null = null;
   let selectedTransitionIds: { outgoingId: string; incomingId: string } | null = null;
   let dropTargetTime: number | null = null;
@@ -996,15 +999,14 @@
     else renderFrame(currentTime);
   }
 
-  function previewAssetOnly(element: Element) {
-    if (element.kind !== 'asset' || !element.assetName) return;
-    const asset = assets.get(element.assetName);
-    if (asset) {
+  function previewAssetOnly(asset: Asset) {
+    const loaded = assets.get(asset.name);
+    if (loaded) {
       previewAsset = {
-        src: asset.src,
-        width: asset.width,
-        height: asset.height,
-        type: isLoadedVideo(asset) ? 'video' : 'image',
+        src: loaded.src,
+        width: loaded.width,
+        height: loaded.height,
+        type: isLoadedVideo(loaded) ? 'video' : 'image',
       };
     }
   }
@@ -1013,12 +1015,11 @@
     previewAsset = null;
   }
 
-  function handleAssetDragStart(event: DragEvent, element: Element) {
-    if (!element.assetName) return;
-    draggingAsset = element;
+  function handleAssetDragStart(event: DragEvent, asset: Asset) {
+    draggingAsset = asset;
     if (event.dataTransfer) {
       event.dataTransfer.effectAllowed = 'copy';
-      event.dataTransfer.setData('text/plain', element.assetName);
+      event.dataTransfer.setData('text/plain', asset.name);
     }
   }
 
@@ -1029,10 +1030,32 @@
   }
 
   async function handleAssetUpload(event: Event) {
+    await importAssetFiles((event.currentTarget as HTMLInputElement).files);
+    assetInput.value = '';
+  }
+
+  async function handleAssetFileDrop(event: DragEvent) {
+    event.preventDefault();
+    isDraggingUpload = false;
+    await importAssetFiles(event.dataTransfer?.files);
+  }
+
+  function handleAssetFileDrag(event: DragEvent) {
+    if (event.dataTransfer?.types.includes('Files')) isDraggingUpload = true;
+  }
+
+  function handleAssetFileDragLeave(event: DragEvent) {
+    if (!(event.currentTarget as HTMLElement).contains(event.relatedTarget as Node | null)) {
+      isDraggingUpload = false;
+    }
+  }
+
+  async function importAssetFiles(fileList: FileList | null | undefined) {
     if (!ast) return;
     const program = ast;
     assetError = '';
-    const files = Array.from((event.currentTarget as HTMLInputElement).files ?? []);
+    const files = Array.from(fileList ?? []);
+    if (!files.length) return;
     for (const file of files) {
       const lowerName = file.name.toLowerCase();
       const isImage = file.type.startsWith('image/') || lowerName.endsWith('.svg');
@@ -1048,9 +1071,40 @@
       }
       let path = '';
       try {
-        path = await readFileDataUrl(file);
+        path = tagEmbeddedAssetPath(await readFileDataUrl(file), file.name);
       } catch (cause) {
         assetError = cause instanceof Error ? cause.message : `Could not read ${file.name}.`;
+        continue;
+      }
+      const matchingImports = program.body.filter(
+        (node) => node.type === 'Import' && assetFilename(node.path) === file.name
+      );
+      if (matchingImports.length) {
+        const existing = matchingImports
+          .map((node) => assets.get(node.name))
+          .find((asset): asset is LoadedAsset => !!asset);
+        let replacement: AssetIdentity;
+        try {
+          replacement = await readMediaIdentity(file, isVideo);
+        } catch (cause) {
+          assetError = cause instanceof Error ? cause.message : `Could not inspect ${file.name}.`;
+          continue;
+        }
+        if (
+          existing &&
+          significantlyDifferentAsset(
+            { width: existing.width, height: existing.height, size: existing.motionlySize },
+            replacement
+          ) &&
+          !window.confirm(
+            `${file.name} has very different size or dimensions from the current asset. Replace it anyway?`
+          )
+        ) {
+          assetError = `Kept the current ${file.name}.`;
+          continue;
+        }
+        for (const node of matchingImports) node.path = path;
+        assetError = `Matched ${file.name} to its existing import by filename.`;
         continue;
       }
       const used = new Set(program.body.flatMap((node) => node.type === 'Import' ? [node.name] : node.type === 'Element' ? [node.name] : []));
@@ -1058,20 +1112,31 @@
       let name = base;
       let suffix = 2;
       while (used.has(name)) name = `${base}_${suffix++}`;
-      program.body.push(
-        { type: 'Import', path, name },
-        {
-          type: 'Element',
-          kind: 'asset',
-          name,
-          properties: isVideo
-            ? { center: true, layer: 'content' }
-            : { center: true, width: 480, layer: 'content' },
-        }
-      );
+      program.body.push({ type: 'Import', path, name });
     }
-    assetInput.value = '';
     code = serializeProgram(program);
+  }
+
+  async function readMediaIdentity(file: File, isVideo: boolean) {
+    const url = URL.createObjectURL(file);
+    try {
+      if (isVideo) {
+        const video = document.createElement('video');
+        video.preload = 'metadata';
+        video.src = url;
+        await new Promise<void>((resolve, reject) => {
+          video.onloadedmetadata = () => resolve();
+          video.onerror = () => reject(video.error ?? new Error(`Could not inspect ${file.name}.`));
+        });
+        return { width: video.videoWidth, height: video.videoHeight, size: file.size };
+      }
+      const image = new Image();
+      image.src = url;
+      await image.decode();
+      return { width: image.naturalWidth, height: image.naturalHeight, size: file.size };
+    } finally {
+      URL.revokeObjectURL(url);
+    }
   }
 
   function readFileDataUrl(file: File): Promise<string> {
@@ -1102,8 +1167,7 @@
     event.preventDefault();
     if (!draggingAsset || !ast || dropTargetTime === null) return;
     
-    const assetName = draggingAsset.assetName;
-    if (!assetName) return;
+    const assetName = draggingAsset.name;
     const frame = 1 / (scene?.canvas.fps ?? 60);
     const loadedAsset = assets.get(assetName);
     const naturalDuration = isLoadedVideo(loadedAsset) && loadedAsset.motionlyDuration > 0
@@ -1130,7 +1194,7 @@
       const runtimeClip: Clip = {
         id: newId,
         assetName,
-        asset: draggingAsset.asset,
+        asset: draggingAsset,
         track: targetTrack.id,
         start,
         duration,
@@ -2299,15 +2363,30 @@
           {#if mediaSubTab === 'assets'}
             <div class="panel-header-actions">
               <input bind:this={assetInput} class="file-input" type="file" accept="image/*,video/mp4,video/webm,.svg,.mp4,.webm,.m4v" multiple on:change={handleAssetUpload} />
-              <button type="button" class="header-icon-btn" on:click={() => assetInput.click()} title="Upload assets" aria-label="Upload assets">
-                <Upload size={16} />
-              </button>
             </div>
           {/if}
         </div>
         <div class="panel-content">
           {#if mediaSubTab === 'assets'}
-            {#if assetError}<p class="asset-error">{assetError}</p>{/if}
+            <div
+              class="media-dropzone"
+              class:drag-active={isDraggingUpload}
+              role="region"
+              aria-label="Import media by dropping files"
+              on:dragenter={handleAssetFileDrag}
+              on:dragover|preventDefault={handleAssetFileDrag}
+              on:dragleave={handleAssetFileDragLeave}
+              on:drop={handleAssetFileDrop}
+            >
+              {#if assetError}<p class="asset-error">{assetError}</p>{/if}
+              <div class="media-drop-prompt">
+                <button type="button" class="import-media-button" on:click={() => assetInput.click()}>
+                  <Upload size={15} />
+                  Import media
+                </button>
+                <span>or drag & drop from your device</span>
+                <small>Images, SVG, MP4, and WebM</small>
+              </div>
             <!-- Audio Section -->
             {#if scene?.audio}
               <div class="asset-folder">
@@ -2330,34 +2409,34 @@
             {/if}
 
             <!-- Visual Assets Section -->
-            {#if sourceElements.filter(el => el.kind === 'asset').length > 0}
+            {#if scene && scene.imports.length > 0}
               <div class="asset-folder">
                 <div class="folder-header">
                   <FileImage size={14} />
-                  <span class="folder-title">Images & Graphics</span>
-                  <span class="folder-count">{sourceElements.filter(el => el.kind === 'asset').length}</span>
+                  <span class="folder-title">Media</span>
+                  <span class="folder-count">{scene.imports.length}</span>
                 </div>
                 <div class="asset-grid">
-                  {#each sourceElements.filter(el => el.kind === 'asset') as element}
+                  {#each scene.imports as asset}
                     <button
                       type="button"
                       class="asset-card"
                       draggable="true"
-                      on:click={() => previewAssetOnly(element)}
-                      on:dragstart={(e) => handleAssetDragStart(e, element)}
+                      on:click={() => previewAssetOnly(asset)}
+                      on:dragstart={(e) => handleAssetDragStart(e, asset)}
                       on:dragend={handleAssetDragEnd}
                     >
                       <div class="asset-thumbnail">
-                        {#if element.asset?.type === 'video' && element.asset.path}
-                          <video src={assets.get(element.assetName ?? '')?.src ?? element.asset.path} muted playsinline preload="metadata"></video>
-                        {:else if element.asset?.path}
-                          <img src={assets.get(element.assetName ?? '')?.src ?? element.asset.path} alt={element.id} />
+                        {#if asset.type === 'video'}
+                          <video src={assets.get(asset.name)?.src ?? asset.path} muted playsinline preload="metadata"></video>
+                        {:else if asset.path}
+                          <img src={assets.get(asset.name)?.src ?? asset.path} alt={asset.name} />
                         {:else}
                           <FileImage size={24} />
                         {/if}
                       </div>
                       <div class="asset-info">
-                        <div class="asset-name">{element.id}</div>
+                        <div class="asset-name">{asset.name}</div>
                       </div>
                     </button>
                   {/each}
@@ -2366,9 +2445,10 @@
             {/if}
 
             <!-- Empty State -->
-            {#if !scene?.audio && sourceElements.filter(el => el.kind === 'asset').length === 0}
-              <p class="empty-state">No assets in project</p>
+            {#if !scene?.audio && scene?.imports.length === 0}
+              <p class="empty-state">Imported media will stay here until you drag it onto the timeline.</p>
             {/if}
+            </div>
           {:else if mediaSubTab === 'presets'}
             <div class="preset-grid">
               {#each availablePresets as preset}
@@ -3569,6 +3649,77 @@
     color: #f09b9b;
     font-size: 11px;
     line-height: 1.4;
+  }
+
+  .media-dropzone {
+    min-height: 100%;
+    box-sizing: border-box;
+    padding: 18px 12px;
+    border: 1px dashed #4b5060;
+    border-radius: 8px;
+    color: #b9b8e8;
+    text-align: center;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .media-drop-prompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 7px;
+    margin-bottom: 16px;
+  }
+
+  .media-dropzone.drag-active {
+    border-color: #79e4bb;
+    background: rgba(77, 140, 117, 0.16);
+    animation: upload-pulse 0.8s ease-in-out infinite alternate;
+  }
+
+  @keyframes upload-pulse {
+    to {
+      transform: scale(1.015);
+      box-shadow: 0 0 18px rgba(121, 228, 187, 0.2);
+    }
+  }
+
+  .media-dropzone:has(.import-media-button:hover) {
+    border-color: #4d8c75;
+  }
+
+  .media-drop-prompt span,
+  .media-drop-prompt small {
+    font-size: 11px;
+  }
+
+  .media-drop-prompt small {
+    color: #777b88;
+  }
+
+  .import-media-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    width: 100%;
+    padding: 9px 12px;
+    border: 1px solid #4d8c75;
+    border-radius: 6px;
+    background: #1a3b30;
+    color: #9af8d1;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .import-media-button:hover {
+    background: #1a3028;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .media-dropzone.drag-active {
+      animation: none;
+    }
   }
 
   .panel-description {

--- a/templates/motionly-skill/SKILL.md
+++ b/templates/motionly-skill/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: motionly
+description: Create, edit, validate, and preview editable Motionly .motion animation projects. Use for Motionly storyboards, motion graphics, local assets, timing, presets, and project.motion files.
+---
+
+# Motionly projects
+
+Motionly is a visual motion-graphics editor. Its editable source is `project.motion`; normal users refine it in the editor rather than hand-writing it. Keep generated source readable and load it through Motionly's parser and renderer.
+
+## Project and asset workflow
+
+- Read `AGENTS.md`, `project.motion`, and relevant files in `assets/` before editing.
+- Reference media by filename under `assets/`: `import "./assets/logo.svg" as logo`.
+- Keep filenames stable. A browser upload with the same filename resolves the same import. If its size or dimensions differ significantly, ask before replacing it.
+- Preserve aspect ratio by setting only `width` or `height`.
+- Use one focal subject per shot and purposeful scene changes. Avoid constant camera drift and the same fade on every layer.
+
+## Supported source
+
+```motion
+canvas {
+  size 1920x1080
+  fps 60
+  duration 5s
+  background #020308
+}
+
+camera {
+  zoom 1
+  cameraAnimation "speedZoom(delay 3s duration 1s from 1 peak 1.08 to 1.02 ease power3.out)"
+}
+
+import "./assets/logo.svg" as logo
+
+logo {
+  center
+  layer hero
+  width 240
+  opacity 1
+  animation "maskReveal(delay 300ms duration 800ms direction down ease power3.out)"
+}
+
+text title {
+  value "Make it move."
+  center
+  layer text
+  y 180
+  size 72
+  color #ffffff
+  opacity 1
+  textAnimation "keynoteText(split words stagger 80ms duration 750ms delay 1s ease power3.out)"
+}
+```
+
+- Use one `canvas`; `camera` is optional.
+- Render an imported asset with its alias directly. Do not invent `asset`, `video`, `scene`, `group`, `rect`, or `layer` block types.
+- Built-in visual blocks are `text`, `overlay`, and `effect`.
+- Valid layers: `background`, `hero`, `supporting`, `content`, `details`, `text`, `effects`.
+- Common properties: `x`, `y`, `width`, `height`, `scale`, `rotation`, `opacity`, `blur`, `size`, `weight`, `color`, `fill`, `center`, `cover`, `layer`, `duration`, `delay`, `easing`.
+- Use `size`, not `fontSize`. Explicit animations use `easing`; preset options use `ease`.
+
+Explicit animation:
+
+```motion
+animate title {
+  from {
+    opacity 0
+    y 80
+    blur 10
+  }
+
+  to {
+    opacity 1
+    y 0
+    blur 0
+  }
+
+  duration 1s
+  delay 0s
+  easing power3.out
+}
+```
+
+Keyframes are percentage blocks inside `keyframes` inside `animate`. Persistent timeline rows use `track NAME { ... }`; media clips use `clip ALIAS { track NAME start 0s duration 5s trimIn 0s trimOut 0s }`. Project audio is `audio "./assets/music.mp3" { start 0s }`.
+
+Prefer `power3.out`. Useful text presets: `keynoteText`, `wordReveal`, `charReveal`, `splitReveal`, `blurReveal`, `fadeUp`, `slideIn`, `scaleText`, `typewriter`, `maskReveal`, `gradientReveal`. Useful object/transition presets: `softReveal`, `maskReveal`, `dynamicSlide`, `shapeWipe`, `irisWipe`, `drawSVG`, `sceneExit`, `scaleReveal`. Use `drawSVG` only for simple stroked SVG logos. Camera presets include `slowPush`, `pan`, `pull`, and `speedZoom`.
+
+## Validate and preview
+
+From the project folder:
+
+```bash
+npx motionly dev
+```
+
+This loads `project.motion` and `assets/`, opens the editor, and saves changes back to `project.motion`. Verify the canvas size, FPS, exact duration, imports, readable holds, transitions, final frame, and save/reload behavior before finishing.

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -1,0 +1,79 @@
+# Motionly Agent Notes
+
+Keep Motionly simple and visual.
+
+Read the installed `motionly` skill before creating or substantially editing `project.motion`.
+
+## Product Rule
+
+Motionly is a motion graphics editor around `.motion`. The user edits visually; `.motion` is the saved source format underneath.
+
+Do not make users hand-write `.motion` for normal animation creation.
+
+## Project Files
+
+- `project.motion` is the editable animation source.
+- Keep local media in `assets/` and reference it by filename, such as `./assets/logo.svg`.
+- Preserve asset aspect ratios by setting only `width` or `height`.
+- Run `npx motionly dev` to load, validate, preview, and visually refine the project.
+
+## `.motion` Syntax
+
+Use this shape:
+
+```motion
+canvas {
+  size 1920x1080
+  fps 60
+  duration 5s
+  background #020308
+}
+
+text title {
+  value "Hello"
+  center
+  size 72
+  color #ffffff
+  opacity 1
+}
+
+animate title {
+  from {
+    opacity 0
+    y 80
+    blur 10
+  }
+
+  to {
+    opacity 1
+    y 0
+    blur 0
+  }
+
+  duration 1.2s
+  delay 0s
+  easing power3.out
+}
+```
+
+Prefer these properties: `x`, `y`, `scale`, `rotation`, `opacity`, `blur`, `size`, `color`, `center`, `duration`, `delay`, `easing`.
+
+Use `size`, not `fontSize`. Use `easing`, not `ease`.
+
+## Preset Guidance
+
+Presets should be subtle:
+
+- Fade in: `opacity 0` to target opacity
+- Rise in: `opacity 0`, `y + 80` to target
+- Scale in: `opacity 0`, `scale .85` to target
+- Blur reveal: `opacity 0`, `blur 12`, slight `y` offset to target
+- Soft drift: slight `x` offset to target
+
+Default to `power3.out` for smooth professional motion.
+
+Build scenes around one focal subject. Use scene color changes and purposeful object movement to mark progression; avoid constant camera drift and repeating the same fade on every object.
+
+For simple stroked SVG logos, `animation drawSVG(...)` animates their paths and resolves into the original artwork. Use it sparingly on a hero logo; use normal image reveals for detailed SVGs, mockups, and photos.
+
+Use the small transition set when a shot actually changes: `shapeWipe`, `irisWipe`, `maskReveal`, `dynamicSlide`, and camera `speedZoom`. Prefer one strong transition per scene over stacking effects.

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -1,0 +1,17 @@
+# {{name}}
+
+This is a local Motionly project.
+
+Motionly starts the project automatically after `init`. To reopen it later:
+
+```bash
+npx motionly dev
+```
+
+Motionly opens `project.motion`, resolves media from `assets/` by filename, and saves visual edits back to the project file. Put images, SVG, video, and audio in `assets/`, then import them from `project.motion`, for example:
+
+```motion
+import "./assets/logo.svg" as logo
+```
+
+The browser-only Motionly editor remains available with `npx motionly`.

--- a/templates/project/meta.json
+++ b/templates/project/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "{{name}}",
+  "created": "{{created}}",
+  "version": 1
+}

--- a/templates/project/project.motion
+++ b/templates/project/project.motion
@@ -1,0 +1,32 @@
+canvas {
+  size 1920x1080
+  fps 60
+  duration 5s
+  background #020308
+}
+
+text title {
+  value "{{name}}"
+  center
+  size 72
+  color #ffffff
+  opacity 1
+}
+
+animate title {
+  from {
+    opacity 0
+    y 80
+    blur 10
+  }
+
+  to {
+    opacity 1
+    y 0
+    blur 0
+  }
+
+  duration 1.2s
+  delay 0s
+  easing power3.out
+}

--- a/tests/assets/asset-resolution.test.ts
+++ b/tests/assets/asset-resolution.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assetFilename,
+  significantlyDifferentAsset,
+  tagEmbeddedAssetPath,
+} from '../../src/assets/asset-resolution';
+
+describe('asset filename resolution', () => {
+  it('uses the same filename for local and embedded browser assets', () => {
+    expect(assetFilename('./assets/My%20Logo.svg?version=2')).toBe('My Logo.svg');
+    expect(assetFilename('motionly-local:My%20Logo.svg')).toBe('My Logo.svg');
+    expect(
+      assetFilename(tagEmbeddedAssetPath('data:image/svg+xml;base64,PHN2Zz4=', 'My Logo.svg'))
+    ).toBe('My Logo.svg');
+    expect(assetFilename('./assets/100%.svg')).toBe('100%.svg');
+  });
+
+  it('only warns for materially different content', () => {
+    expect(
+      significantlyDifferentAsset(
+        { width: 1920, height: 1080, size: 1_000_000 },
+        { width: 1900, height: 1060, size: 1_100_000 }
+      )
+    ).toBe(false);
+    expect(
+      significantlyDifferentAsset(
+        { width: 1920, height: 1080, size: 1_000_000 },
+        { width: 640, height: 360, size: 100_000 }
+      )
+    ).toBe(true);
+  });
+});

--- a/tests/cli/local-workflow.test.ts
+++ b/tests/cli/local-workflow.test.ts
@@ -1,0 +1,133 @@
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:net';
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const exec = promisify(execFile);
+const cli = resolve('bin/motionly.js');
+let workspace = '';
+
+async function availablePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+  return port;
+}
+
+afterEach(async () => {
+  if (workspace) await rm(workspace, { recursive: true, force: true });
+});
+
+describe('local CLI workflow', () => {
+  it('installs supported skills and scaffolds a project without overwriting them', async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'motionly-cli-'));
+    await exec(process.execPath, [cli, 'skills', 'add', '--all', '--scope', 'project'], {
+      cwd: workspace,
+    });
+
+    for (const path of [
+      '.claude/skills/motionly/SKILL.md',
+      '.agents/skills/motionly/SKILL.md',
+      '.gemini/skills/motionly/SKILL.md',
+      '.kiro/skills/motionly/SKILL.md',
+    ]) {
+      expect((await stat(join(workspace, path))).isFile()).toBe(true);
+    }
+
+    const initialized = await exec(process.execPath, [cli, 'init', 'demo'], { cwd: workspace });
+    expect(initialized.stdout).not.toContain('Next:');
+    expect(await readFile(join(workspace, 'demo', 'meta.json'), 'utf8')).toContain(
+      '"name": "demo"'
+    );
+    expect(await readFile(join(workspace, 'demo', 'AGENTS.md'), 'utf8')).toContain(
+      '## `.motion` Syntax'
+    );
+    expect(await readFile(join(workspace, 'demo', 'project.motion'), 'utf8')).toContain(
+      'easing power3.out'
+    );
+    expect((await stat(join(workspace, 'demo', 'assets'))).isDirectory()).toBe(true);
+  });
+
+  it('installs supported skills globally when requested', async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'motionly-global-skills-'));
+    const home = join(workspace, 'home');
+    await mkdir(home);
+
+    await exec(process.execPath, [cli, 'skills', 'add', '--all', '--scope', 'global'], {
+      cwd: workspace,
+      env: { ...process.env, HOME: home },
+    });
+
+    for (const path of [
+      '.claude/skills/motionly/SKILL.md',
+      '.agents/skills/motionly/SKILL.md',
+      '.gemini/skills/motionly/SKILL.md',
+      '.kiro/skills/motionly/SKILL.md',
+    ]) {
+      expect((await stat(join(home, path))).isFile()).toBe(true);
+    }
+
+    const initialized = await exec(process.execPath, [cli, 'init', 'demo'], {
+      cwd: workspace,
+      env: { ...process.env, HOME: home },
+    });
+    expect(initialized.stdout).not.toContain('Next:');
+  });
+
+  it('loads, serves, and saves a scaffolded local project', async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'motionly-dev-'));
+    await exec(process.execPath, [cli, 'init', 'demo'], { cwd: workspace });
+    await writeFile(join(workspace, 'demo', 'assets', 'logo.svg'), '<svg></svg>');
+    const port = await availablePort();
+    const child = spawn(
+      process.execPath,
+      [cli, 'dev', 'demo', '--port', String(port), '--no-open'],
+      { cwd: workspace, stdio: 'ignore' }
+    );
+
+    try {
+      let response: Response | undefined;
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        try {
+          response = await fetch(`http://127.0.0.1:${port}/api/motion-project`);
+          break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      }
+      expect(response?.ok).toBe(true);
+      const source = await response!.text();
+      expect(source).toContain('value "demo"');
+
+      const editor = await fetch(`http://127.0.0.1:${port}/editor`);
+      const script = (await editor.text()).match(/<script[^>]+src="([^"]+)"/)?.[1];
+      expect(script).toBeTruthy();
+      const bundle = await fetch(`http://127.0.0.1:${port}${script}`);
+      expect(bundle.headers.get('content-type')).toContain('text/javascript');
+
+      const asset = await fetch(`http://127.0.0.1:${port}/assets/logo.svg`, { method: 'HEAD' });
+      expect(asset.headers.get('content-length')).toBe('11');
+
+      const updated = source.replace('value "demo"', 'value "Saved"');
+      const saved = await fetch(`http://127.0.0.1:${port}/api/motion-project`, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: updated,
+      });
+      expect(saved.status).toBe(204);
+      expect(await readFile(join(workspace, 'demo', 'project.motion'), 'utf8')).toContain(
+        'value "Saved"'
+      );
+    } finally {
+      child.kill();
+    }
+  });
+});


### PR DESCRIPTION
 ## Summary

  - Add a zero-dependency Motionly CLI with:
    - `motionly skills add`
    - `motionly init <folder>`
    - `motionly dev [folder]`
  - Add an interactive agent-skill installer with Project, Global, and Skip options for Claude Code, Codex, Gemini CLI, and Kiro
  CLI.
  - Scaffold editable local projects with `project.motion`, `assets/`, `AGENTS.md`, metadata, and usage instructions.
  - Load and save `project.motion` through the local editor and automatically start the editor after initialization.
  - Resolve local and browser-uploaded assets by filename, with confirmation before replacing materially different media.
  - Add drag-and-drop media importing, project templates, agent guidance, CLI tests, asset-resolution tests, and public
  documentation.

  ## Testing

  - `npm test -- --run`
    - 33 test files passed
    - 161 tests passed
  - `npm run build`
  - Installed the packed npm tarball in a fresh temporary workspace.
  - Tested `npx motionly init demo` with Project scope and all supported agents.
  - Verified the editor started at `http://localhost:4173/editor`.
  - Verified local project loading, asset serving, and saving changes to `project.motion`.

  ## Risk

  - Global skill installation writes into agent-specific folders under the user’s home directory.
  - Existing skill files are preserved and are not overwritten.
  - Local editor saving writes directly to the selected project’s `project.motion`.
  - Asset matching uses exact filenames. Materially different replacements require confirmation.
  - Publishing is currently blocked by an unintended local tarball dependency in `package.json`; remove it before merging or
  publishing.

  ## Checklist

  - [x] I ran `npm test`.
  - [ ] I kept the change scoped and readable.
  - [x] I updated docs for syntax, preset, export, or public behavior changes.
  - [x] I did not mutate imported assets or add hidden renderer state.