### PR TITLE
• feat(editor):  audio editing

### DIFF
--- a/src/animation/evaluator.ts
+++ b/src/animation/evaluator.ts
@@ -14,52 +14,62 @@ import type {
   Keyframe,
   PropertyMap,
   ElementProperties,
+  Clip,
+  Track,
 } from '../types/scene';
+
+interface PreparedScene {
+  animationsByTarget: Map<string, Animation[]>;
+  clippedAssets: Set<string>;
+  clipsById: Map<string, Clip>;
+  elementsByAsset: Map<string, Element>;
+  orderedClips: Clip[];
+  regularElements: Element[];
+  tracksById: Map<string, Track>;
+}
+
+const preparedScenes = new WeakMap<Scene, PreparedScene>();
+const interpolatedKeys = new WeakMap<Animation, string[]>();
 
 /**
  * Evaluate scene at a specific time
  * Returns the scene with all animations applied
  */
 export function evaluateScene(scene: Scene, time: number): EvaluatedScene {
-  const camera = evaluateCamera(scene, time);
-  const clippedAssets = new Set(scene.clips.map((clip) => clip.assetName));
+  const prepared = prepareScene(scene);
+  const camera = evaluateCamera(scene, prepared, time);
 
   // Evaluate regular elements
-  const elements = scene.elements
-    .filter(
-      (element) =>
-        (element.kind !== 'asset' || !element.assetName || !clippedAssets.has(element.assetName)) &&
-        elementTrackVisible(scene, element) &&
-        elementWindowActive(element, time)
-    )
+  const elements = prepared.regularElements
+    .filter((element) => elementWindowActive(element, time))
     .map((element) => {
-      const render = evaluateElement(element, scene.animations, time);
-      if (element.asset?.type === 'video') render.mediaTime = Math.max(0, time);
+      let render = evaluateElement(
+        element,
+        prepared.animationsByTarget.get(element.id) ?? [],
+        time
+      );
+      if (element.asset?.type === 'video') {
+        render = { ...render, mediaTime: Math.max(0, time) } as ElementProperties;
+      }
       return { ...element, render };
     });
 
   // Visual tracks stack bottom-to-top: higher track numbers render last.
   // Authored source order is the explicit same-track tie-breaker.
-  const activeClips = scene.clips
-    .filter((clip) => {
-      const track = scene.tracks.find((candidate) => candidate.id === String(clip.track));
-      if (track?.role === 'audio' || track?.hidden) return false;
-      const transitionTail = clip.transitionOut === 'crossfade' ? clip.transitionOutDuration : 0;
-      return time >= clip.start && time < clip.start + clip.duration + transitionTail;
-    })
-    .sort(
-      (a, b) =>
-        clipTrackRank(scene, a.track) - clipTrackRank(scene, b.track) ||
-        a.sourceOrder - b.sourceOrder
-    );
+  const activeClips = prepared.orderedClips.filter((clip) => {
+    const transitionTail = clip.transitionOut === 'crossfade' ? clip.transitionOutDuration : 0;
+    return time >= clip.start && time < clip.start + clip.duration + transitionTail;
+  });
 
   for (const clip of activeClips) {
     if (!clip.asset) continue;
-    const sourceElement = scene.elements.find(
-      (element) => element.kind === 'asset' && element.assetName === clip.assetName
-    );
+    const sourceElement = prepared.elementsByAsset.get(clip.assetName);
     const sourceRender = sourceElement
-      ? evaluateElement(sourceElement, scene.animations, time)
+      ? evaluateElement(
+          sourceElement,
+          prepared.animationsByTarget.get(sourceElement.id) ?? [],
+          time
+        )
       : ({
           x: 0,
           y: 0,
@@ -94,20 +104,70 @@ export function evaluateScene(scene: Scene, time: number): EvaluatedScene {
         mediaTrimOut: clip.trimOut,
         mediaVolume: clip.volume ?? 1,
         mediaMuted:
-          (scene.tracks.find((track) => track.id === String(clip.track))?.muted ?? false) ||
-          (clip.mute ?? false),
+          (prepared.tracksById.get(String(clip.track))?.muted ?? false) || (clip.mute ?? false),
       } as ElementProperties,
     };
 
     elements.push(clipElement);
   }
 
-  elements.sort((left, right) => elementTrackRank(scene, left) - elementTrackRank(scene, right));
+  elements.sort(
+    (left, right) => elementTrackRank(prepared, left) - elementTrackRank(prepared, right)
+  );
   return { canvas: scene.canvas, camera, elements };
 }
 
-function clipTrackRank(scene: Scene, trackId: number | string): number {
-  const track = scene.tracks.find((candidate) => candidate.id === String(trackId));
+function prepareScene(scene: Scene): PreparedScene {
+  const cached = preparedScenes.get(scene);
+  if (cached) return cached;
+
+  const animationsByTarget = new Map<string, Animation[]>();
+  for (const animation of scene.animations) {
+    const targetAnimations = animationsByTarget.get(animation.target);
+    if (targetAnimations) targetAnimations.push(animation);
+    else animationsByTarget.set(animation.target, [animation]);
+  }
+
+  const tracksById = new Map(scene.tracks.map((track) => [track.id, track]));
+  const elementsByAsset = new Map<string, Element>();
+  for (const element of scene.elements) {
+    if (element.kind === 'asset' && element.assetName && !elementsByAsset.has(element.assetName)) {
+      elementsByAsset.set(element.assetName, element);
+    }
+  }
+
+  const prepared: PreparedScene = {
+    animationsByTarget,
+    clippedAssets: new Set(scene.clips.map((clip) => clip.assetName)),
+    clipsById: new Map(scene.clips.map((clip) => [clip.id, clip])),
+    elementsByAsset,
+    orderedClips: [],
+    regularElements: [],
+    tracksById,
+  };
+  prepared.regularElements = scene.elements.filter(
+    (element) =>
+      (element.kind !== 'asset' ||
+        !element.assetName ||
+        !prepared.clippedAssets.has(element.assetName)) &&
+      elementTrackVisible(prepared, element)
+  );
+  prepared.orderedClips = scene.clips
+    .filter((clip) => {
+      const track = prepared.tracksById.get(String(clip.track));
+      return track?.role !== 'audio' && !track?.hidden;
+    })
+    .sort(
+      (left, right) =>
+        clipTrackRank(prepared, left.track) - clipTrackRank(prepared, right.track) ||
+        left.sourceOrder - right.sourceOrder
+    );
+  preparedScenes.set(scene, prepared);
+  return prepared;
+}
+
+function clipTrackRank(prepared: PreparedScene, trackId: number | string): number {
+  const track = prepared.tracksById.get(String(trackId));
   if (track) return track.role === 'main' ? 0 : 100 + track.order;
   return trackRank(trackId);
 }
@@ -121,21 +181,21 @@ function elementWindowActive(element: Element, time: number): boolean {
   return time >= start && time < start + Math.max(0, duration);
 }
 
-function elementTrackVisible(scene: Scene, element: Element): boolean {
+function elementTrackVisible(prepared: PreparedScene, element: Element): boolean {
   const trackId = (element.properties as unknown as Record<string, unknown>)['track'];
   if (trackId === undefined) return true;
-  const track = scene.tracks.find((candidate) => candidate.id === String(trackId));
+  const track = prepared.tracksById.get(String(trackId));
   return track?.role !== 'audio' && !track?.hidden;
 }
 
 function elementTrackRank(
-  scene: Scene,
+  prepared: PreparedScene,
   element: import('../types/scene').EvaluatedElement
 ): number {
-  const clip = scene.clips.find((candidate) => candidate.id === element.id);
-  if (clip) return clipTrackRank(scene, clip.track);
+  const clip = prepared.clipsById.get(element.id);
+  if (clip) return clipTrackRank(prepared, clip.track);
   const trackId = (element.render as unknown as Record<string, unknown>)['track'];
-  if (trackId !== undefined) return clipTrackRank(scene, String(trackId));
+  if (trackId !== undefined) return clipTrackRank(prepared, String(trackId));
   return 1000;
 }
 
@@ -147,7 +207,7 @@ function trackRank(track: number | string): number {
 /**
  * Evaluate camera state at a specific time
  */
-function evaluateCamera(scene: Scene, time: number): ElementProperties {
+function evaluateCamera(scene: Scene, prepared: PreparedScene, time: number): ElementProperties {
   const cameraElement: Element = {
     id: 'camera',
     kind: 'asset',
@@ -160,7 +220,11 @@ function evaluateCamera(scene: Scene, time: number): ElementProperties {
       rotation: 0,
     }) as unknown as ElementProperties,
   };
-  return evaluateElement(cameraElement, scene.animations, time);
+  return evaluateElement(
+    cameraElement,
+    prepared.animationsByTarget.get(cameraElement.id) ?? [],
+    time
+  );
 }
 
 /**
@@ -171,12 +235,14 @@ function evaluateElement(
   animations: Animation[],
   time: number
 ): ElementProperties {
+  if (animations.length === 0) return element.properties;
+
   let state: Record<string, unknown> = { ...element.properties } as unknown as Record<
     string,
     unknown
   >;
 
-  for (const animation of animations.filter((item) => item.target === element.id)) {
+  for (const animation of animations) {
     state = applyAnimation(state as PropertyMap, animation, time) as unknown as Record<
       string,
       unknown
@@ -204,7 +270,11 @@ function applyAnimation(state: PropertyMap, animation: Animation, time: number):
 
   const progress = ease(rawProgress, animation.easing);
   const next: PropertyMap = { ...state };
-  const keys = new Set([...Object.keys(animation.from), ...Object.keys(animation.to)]);
+  let keys = interpolatedKeys.get(animation);
+  if (!keys) {
+    keys = [...new Set([...Object.keys(animation.from), ...Object.keys(animation.to)])];
+    interpolatedKeys.set(animation, keys);
+  }
 
   for (const key of keys) {
     const from = animation.from[key] ?? state[key] ?? 0;

--- a/src/assets/asset-loader.ts
+++ b/src/assets/asset-loader.ts
@@ -23,6 +23,8 @@ interface LoadedAssetMetadata {
   motionlySvg?: MotionlySvgData;
   motionlyDuration?: number;
   motionlySize?: number;
+  motionlyPlay?: Promise<void>;
+  motionlySeek?: Promise<void>;
 }
 
 export type LoadedImageAsset = HTMLImageElement &
@@ -153,6 +155,8 @@ export interface VideoSyncOptions {
   exact?: boolean;
 }
 
+const activeVideosByAssetMap = new WeakMap<Map<string, LoadedAsset>, Set<LoadedVideoAsset>>();
+
 export function videoSourceTime(sourceTime: number, duration: number, trimOut = 0): number {
   const maximum = Math.max(0, duration - Math.max(0, trimOut) - 0.001);
   return Math.max(0, Math.min(maximum, Number.isFinite(sourceTime) ? sourceTime : 0));
@@ -177,31 +181,58 @@ export async function synchronizeVideoAssets(
   }
 
   const operations: Promise<void>[] = [];
-  for (const [name, asset] of assets) {
+  const previousActive = activeVideosByAssetMap.get(assets) ?? new Set<LoadedVideoAsset>();
+  const nextActive = new Set<LoadedVideoAsset>();
+  for (const [name, render] of active) {
+    const asset = assets.get(name);
     if (!isLoadedVideo(asset)) continue;
-    const render = active.get(name);
-    if (!render) {
-      asset.pause();
-      continue;
-    }
+    nextActive.add(asset);
     const sourceTime = Number(render['mediaTime'] ?? 0);
     const trimOut = Math.max(0, Number(render['mediaTrimOut'] ?? 0));
     const desired = videoSourceTime(sourceTime, asset.motionlyDuration, trimOut);
     const tolerance = options.exact ? 1 / 1000 : 0.15;
     if (Math.abs(asset.currentTime - desired) > tolerance) {
-      operations.push(seekVideo(asset, desired));
+      operations.push(seekVideoWithoutOverlap(asset, desired, options.exact === true));
     }
     if (options.playing && asset.paused) {
-      operations.push(asset.play().catch(() => undefined));
+      operations.push(playVideo(asset));
     } else if (!options.playing) {
       asset.pause();
     }
   }
+  for (const asset of previousActive) {
+    if (!nextActive.has(asset)) asset.pause();
+  }
+  activeVideosByAssetMap.set(assets, nextActive);
   await Promise.all(operations);
 }
 
 export function pauseVideoAssets(assets: Map<string, LoadedAsset>): void {
   for (const asset of assets.values()) if (isLoadedVideo(asset)) asset.pause();
+  activeVideosByAssetMap.delete(assets);
+}
+
+function playVideo(video: LoadedVideoAsset): Promise<void> {
+  if (video.motionlyPlay) return video.motionlyPlay;
+  const operation = video.play().catch(() => undefined);
+  video.motionlyPlay = operation;
+  return operation.finally(() => {
+    if (video.motionlyPlay === operation) video.motionlyPlay = undefined;
+  });
+}
+
+function seekVideoWithoutOverlap(
+  video: LoadedVideoAsset,
+  time: number,
+  exact: boolean
+): Promise<void> {
+  if (video.motionlySeek && !exact) return video.motionlySeek;
+  const previous = video.motionlySeek?.catch(() => undefined) ?? Promise.resolve();
+  const operation = previous.then(() => seekVideo(video, time));
+  video.motionlySeek = operation;
+  return operation.finally(() => {
+    if (video.motionlySeek === operation) video.motionlySeek = undefined;
+  });
 }
 
 async function seekVideo(video: LoadedVideoAsset, time: number): Promise<void> {

--- a/src/render/canvas-renderer.ts
+++ b/src/render/canvas-renderer.ts
@@ -5,7 +5,7 @@
 
 import type { EvaluatedScene, EvaluatedElement, Canvas, ElementProperties } from '../types/scene';
 import type { BoundingBox } from '../types/export';
-import { isLoadedVideo, type LoadedAsset } from '../assets/asset-loader';
+import { isLoadedVideo, type LoadedAsset, type MotionlySvgData } from '../assets/asset-loader';
 import { formatCountValue } from '../animation-library/count-up';
 
 /**
@@ -43,12 +43,23 @@ export class CanvasRenderer {
   /**
    * Render frame to canvas
    */
-  render(frame: EvaluatedScene, assets: Map<string, LoadedAsset> = new Map()): void {
+  render(
+    frame: EvaluatedScene,
+    assets: Map<string, LoadedAsset> = new Map(),
+    outputScale = 1
+  ): void {
     const { canvas, camera, elements } = frame;
-    this.resize(canvas.width, canvas.height);
+    const scale = Math.max(0.05, Math.min(1, Number.isFinite(outputScale) ? outputScale : 1));
+    this.resize(
+      Math.max(1, Math.round(canvas.width * scale)),
+      Math.max(1, Math.round(canvas.height * scale))
+    );
     const ctx = this.context;
 
     ctx.save();
+    ctx.setTransform(scale, 0, 0, scale, 0, 0);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
     ctx.globalAlpha = 1;
     ctx.filter = 'none';
     ctx.fillStyle = canvas.background;
@@ -67,7 +78,6 @@ export class CanvasRenderer {
           ctx,
           canvas,
           element,
-          laidOut,
           assets,
           elementsById,
           this.maskCanvas,
@@ -84,7 +94,6 @@ export class CanvasRenderer {
           ctx,
           canvas,
           element,
-          laidOut,
           assets,
           elementsById,
           this.maskCanvas,
@@ -235,7 +244,6 @@ function drawElementWithMask(
   ctx: CanvasRenderingContext2D,
   canvas: Canvas,
   element: EvaluatedElement,
-  elements: EvaluatedElement[],
   assets: Map<string, LoadedAsset>,
   elementsById: Map<string, EvaluatedElement>,
   maskCanvas: HTMLCanvasElement,
@@ -243,8 +251,7 @@ function drawElementWithMask(
 ): void {
   const props = element.render as unknown as Record<string, unknown>;
   const maskId = String(props['mask'] ?? '');
-  const maskElement =
-    maskId && maskId !== 'none' ? elements.find((candidate) => candidate.id === maskId) : undefined;
+  const maskElement = maskId && maskId !== 'none' ? elementsById.get(maskId) : undefined;
   if (!maskElement) {
     drawElement(ctx, canvas, element, assets, elementsById);
     return;
@@ -376,9 +383,19 @@ function drawSvgReveal(
     ctx.lineJoin = path.lineJoin;
     ctx.setLineDash([path.length, path.length]);
     ctx.lineDashOffset = path.length * (1 - progress);
-    ctx.stroke(new Path2D(path.d));
+    ctx.stroke(svgPath(path));
   }
   ctx.restore();
+}
+
+const svgPaths = new WeakMap<MotionlySvgData['paths'][number], Path2D>();
+
+function svgPath(path: MotionlySvgData['paths'][number]): Path2D {
+  const cached = svgPaths.get(path);
+  if (cached) return cached;
+  const created = new Path2D(path.d);
+  svgPaths.set(path, created);
+  return created;
 }
 
 /**

--- a/src/ui/MotionlyApp.svelte
+++ b/src/ui/MotionlyApp.svelte
@@ -249,7 +249,7 @@ animate title {
         <FolderOpen size={18} />
         <span class="action-label">Open</span>
       </button>
-      <button on:click={handleSave} class="btn btn-primary" title="Save changes">
+      <button on:click={handleSave} class="btn btn-primary" title="Save changes (Ctrl/Cmd+S)">
         <Save size={18} />
         <span class="action-label">Save</span>
       </button>
@@ -296,7 +296,7 @@ animate title {
   </div>
 
   <!-- Editor -->
-  <MotionEditor bind:this={editor} bind:code={motionCode} />
+  <MotionEditor bind:this={editor} bind:code={motionCode} onSave={handleSave} />
 </div>
 
 <style>

--- a/src/ui/audio-waveform.ts
+++ b/src/ui/audio-waveform.ts
@@ -1,0 +1,62 @@
+export interface AudioPeak {
+  min: number;
+  max: number;
+}
+
+export const MAX_WAVEFORM_BUCKETS = 4096;
+
+export function waveformBucketCount(duration: number): number {
+  if (!Number.isFinite(duration) || duration <= 0) return 64;
+  return Math.min(MAX_WAVEFORM_BUCKETS, Math.max(64, Math.ceil(duration * 80)));
+}
+
+export async function extractAudioPeaks(
+  channels: readonly Float32Array[],
+  requestedBuckets: number,
+  cancelled: () => boolean = () => false
+): Promise<AudioPeak[]> {
+  if (cancelled() || channels.length === 0) return [];
+  const length = Math.min(...channels.map((channel) => channel.length));
+  if (length === 0) return [];
+  const bucketCount = Math.min(
+    length,
+    MAX_WAVEFORM_BUCKETS,
+    Math.max(1, Math.floor(requestedBuckets))
+  );
+  const peaks: AudioPeak[] = [];
+  let highest = 0;
+
+  for (let bucket = 0; bucket < bucketCount; bucket += 1) {
+    if (bucket > 0 && bucket % 64 === 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      if (cancelled()) return [];
+    }
+    const start = Math.floor((bucket * length) / bucketCount);
+    const end = Math.max(start + 1, Math.floor(((bucket + 1) * length) / bucketCount));
+    let min = 1;
+    let max = -1;
+    for (const channel of channels) {
+      for (let sample = start; sample < end; sample += 1) {
+        const value = channel[sample] ?? 0;
+        if (value < min) min = value;
+        if (value > max) max = value;
+      }
+    }
+    highest = Math.max(highest, Math.abs(min), Math.abs(max));
+    peaks.push({ min, max });
+  }
+
+  if (highest <= Number.EPSILON) return peaks.map(() => ({ min: 0, max: 0 }));
+  return peaks.map(({ min, max }) => ({ min: min / highest, max: max / highest }));
+}
+
+export function waveformPath(peaks: readonly AudioPeak[], height = 24): string {
+  if (peaks.length === 0) return '';
+  const center = height / 2;
+  const amplitude = Math.max(0, center - 1);
+  const point = (index: number, value: number) =>
+    `${index + 0.5} ${(center - value * amplitude).toFixed(2)}`;
+  const upper = peaks.map((peak, index) => point(index, peak.max));
+  const lower = peaks.map((peak, index) => point(index, peak.min)).reverse();
+  return `M${upper.join('L')}L${lower.join('L')}Z`;
+}

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -26,14 +26,17 @@
   import { elementWindowProperties, moveElementClip, splitElementClip } from '../element-clips';
   import { restoreEmbeddedAssetPaths } from '../../ai/chat';
   import { createEditorHistory, recordEditorSource, redoEditorSource, undoEditorSource } from '../editor-history';
+  import { editorShortcut } from '../editor-shortcuts';
+  import { extractAudioPeaks, waveformBucketCount, waveformPath } from '../audio-waveform';
   import { moveClipToTrack, removeClipFromTracks, trimClipOnTrack } from '../timeline-tracks';
-  import { anchoredTimelineScroll, clampTimelineZoom, quantizeTimelineTime as quantizeFrameTime } from '../timeline-viewport';
+  import { anchoredTimelineScroll, clampTimelineZoom, playbackTimeFromClock, quantizeTimelineTime as quantizeFrameTime } from '../timeline-viewport';
   import { appUrl } from '../../app/routing';
   import AiChatPanel from './AiChatPanel.svelte';
   import AiConfigPanel from './AiConfigPanel.svelte';
   import BrandConfigPanel from './BrandConfigPanel.svelte';
 
   export let code = '';
+  export let onSave: () => void | Promise<void> = () => undefined;
   let canvas: HTMLCanvasElement;
   let stage: HTMLDivElement;
   let renderer: CanvasRenderer | null = null;
@@ -49,6 +52,7 @@
   let assistantAssets: Asset[] = [];
   let isPlaying = false;
   let currentTime = 0;
+  let playbackTime = 0;
   let totalDuration = 5;
   let animationFrameId: number | null = null;
   let dragState:
@@ -83,11 +87,21 @@
   let audioUrl = '';
   let audioName = '';
   let audioDuration = 0;
+  let audioPlayPromise: Promise<void> | null = null;
+  let audioLoadId = 0;
+  let loadedAudioPath = '';
+  let audioWaveformLoadId = 0;
+  let audioWaveformPath = '';
+  let audioWaveformPeakCount = 0;
+  let audioWaveformLoading = false;
+  let audioClipDuration = 0;
+  let visibleWaveformPeaks = 1;
   let timelineHeight = 230;
   let mp4Supported = false;
   let isExporting = false;
   let exportError = '';
   let assetError = '';
+  let audioError = '';
   let activeNavTab: 'media' | 'audio' | 'text' | 'effects' | 'scenes' | 'ai' | 'settings' = 'media';
   let showAiChat = false;
   let mediaSubTab: 'assets' | 'presets' = 'assets';
@@ -97,6 +111,7 @@
   let videoRenderId = 0;
   let isDraggingUpload = false;
   let draggingAsset: Asset | null = null;
+  let draggingAudio = false;
   let draggingTransition: 'crossfade' | null = null;
   let selectedTransitionIds: { outgoingId: string; incomingId: string } | null = null;
   let dropTargetTime: number | null = null;
@@ -171,22 +186,69 @@
     if (stage) observer.observe(stage);
     requestAnimationFrame(fitPreview);
     
-    // Keyboard handler for Escape to clear preview
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
-      const editing = target?.matches('input, textarea, select, [contenteditable="true"]');
-      if ((e.ctrlKey || e.metaKey) && !editing && e.key.toLowerCase() === 'z') {
-        e.preventDefault();
-        if (e.shiftKey) redoEditor();
-        else undoEditor();
-        return;
+      const interactive = Boolean(target?.closest(
+        'input, textarea, select, button, a, [contenteditable="true"], [role="button"], [role="slider"]'
+      ));
+      const shortcut = editorShortcut(e, interactive);
+      if (!shortcut || showConfirmDialog) return;
+      e.preventDefault();
+      if (e.repeat && !shortcut.startsWith('nudge-')) return;
+
+      const nudge = e.shiftKey ? 10 : 1;
+      switch (shortcut) {
+        case 'save':
+          void onSave();
+          break;
+        case 'undo':
+          undoEditor();
+          break;
+        case 'redo':
+          redoEditor();
+          break;
+        case 'toggle-playback':
+          if (isPlaying) pause();
+          else play();
+          break;
+        case 'delete-selection':
+          deleteSelectedElement();
+          break;
+        case 'nudge-left':
+          nudgeSelectedElement(-nudge, 0);
+          break;
+        case 'nudge-right':
+          nudgeSelectedElement(nudge, 0);
+          break;
+        case 'nudge-up':
+          nudgeSelectedElement(0, -nudge);
+          break;
+        case 'nudge-down':
+          nudgeSelectedElement(0, nudge);
+          break;
+        case 'split':
+          splitSelectedClip();
+          break;
+        case 'reset-playhead':
+          reset();
+          break;
+        case 'clear-selection':
+          if (previewAsset) clearAssetPreview();
+          else if (selectedElementId) {
+            selectedElementId = '';
+            selectedKeyframeOffset = null;
+            selectedTransitionIds = null;
+            renderFrame(currentTime);
+          }
+          break;
       }
-      if (e.key === 'Escape' && previewAsset) clearAssetPreview();
     };
     window.addEventListener('keydown', handleKeyDown);
     
     return () => {
       observer.disconnect();
+      audioLoadId += 1;
+      audioWaveformLoadId += 1;
       if (audioUrl) URL.revokeObjectURL(audioUrl);
       window.removeEventListener('keydown', handleKeyDown);
     };
@@ -298,6 +360,14 @@
   $: timelineClipTracks = combinedTimelineRows.clipTracks;
   $: defaultMainTrack = scene?.tracks.find((track) => track.role === 'main')?.id ?? 'main';
   $: projectAudioTrack = scene?.tracks.find((track) => track.role === 'audio') ?? null;
+  $: audioClipDuration = Math.min(
+    audioDuration || totalDuration,
+    Math.max(0, totalDuration - (scene?.audioStart ?? 0))
+  );
+  $: visibleWaveformPeaks =
+    audioDuration > 0
+      ? Math.max(1, (audioWaveformPeakCount * audioClipDuration) / audioDuration)
+      : Math.max(1, audioWaveformPeakCount);
   $: transitionBoundaries = adjacentClipBoundaries(
     scene?.clips ?? [],
     1 / (scene?.canvas.fps ?? 60)
@@ -340,9 +410,8 @@
       
       // Load audio if specified in scene
       if (scene.audio) {
-        // Check if we need to load/reload audio
         const currentAudioPath = scene.audio;
-        const needsLoad = !audioUrl || !audioName || !currentAudioPath.endsWith(audioName);
+        const needsLoad = !audioUrl || currentAudioPath !== loadedAudioPath;
         
         if (needsLoad) {
           loadAudioFromPath(currentAudioPath);
@@ -368,12 +437,13 @@
   function renderFrame(time: number, exactVideoSeek = false) {
     if (!renderer || !scene) return;
     const frame = evaluateScene(scene, time);
+    const outputScale = previewRenderScale();
     currentFrame = frame;
     const renderId = ++videoRenderId;
     const draw = () => {
       if (!renderer || renderId !== videoRenderId) return;
-      renderer.render(frame, assets);
-      drawSelection();
+      renderer.render(frame, assets, outputScale);
+      drawSelection(outputScale);
     };
     if (exactVideoSeek) {
       void synchronizeVideoAssets(frame, assets, { playing: false, exact: true })
@@ -387,7 +457,7 @@
     draw();
   }
 
-  function drawSelection() {
+  function drawSelection(outputScale = previewRenderScale()) {
     if (!canvas || !currentFrame || !selectedElementId) return;
     const matches = currentFrame.elements.filter((element) => {
       const props = propertiesOf(element);
@@ -405,6 +475,7 @@
     const inset = selectedElement?.kind === 'overlay' || selectedElement?.kind === 'effect' ? 3 / zoom : 0;
     const handleSize = 10 / zoom;
     ctx.save();
+    ctx.setTransform(outputScale, 0, 0, outputScale, 0, 0);
     ctx.strokeStyle = '#7cf7c5';
     ctx.lineWidth = 2 / zoom;
     ctx.setLineDash([8 / zoom, 5 / zoom]);
@@ -452,33 +523,48 @@
   }
 
   function play() {
-    if (!scene) return;
+    if (!scene || isPlaying) return;
     isPlaying = true;
-    resumeAudioAtCurrentTime();
+    playbackTime = currentTime;
+    resumeAudioAtTime(currentTime);
 
     const fps = scene.canvas.fps;
-    const frameTime = 1000 / fps;
-    let lastTime = performance.now();
+    let clockTime = currentTime;
+    let clockStartedAt = performance.now();
+    let previousFrame = -1;
+    let lastUiUpdate = 0;
     
     function animate(now: number) {
       if (!isPlaying) return;
 
-      const delta = now - lastTime;
-      if (delta >= frameTime) {
-        if (audioUrl && audioElement && !audioElement.paused && !audioElement.ended) {
-          currentTime = quantizeTimelineTime((scene?.audioStart ?? 0) + audioElement.currentTime);
-        } else {
-          currentTime = quantizeTimelineTime(currentTime + delta / 1000);
-          resumeAudioAtCurrentTime();
-        }
-        
-        if (currentTime >= totalDuration) {
-          currentTime = totalDuration;
-          pause();
-        }
+      const audioIsClock = Boolean(
+        audioUrl && audioElement && !audioElement.paused && !audioElement.ended
+      );
+      const nextTime = quantizeTimelineTime(
+        audioIsClock
+          ? (scene?.audioStart ?? 0) + audioElement.currentTime
+          : playbackTimeFromClock(clockTime, clockStartedAt, now, totalDuration)
+      );
+      playbackTime = nextTime;
+      if (audioIsClock) {
+        clockTime = nextTime;
+        clockStartedAt = now;
+      } else {
+        resumeAudioAtTime(nextTime);
+      }
 
-        renderFrame(currentTime);
-        lastTime = now;
+      const frame = Math.round(nextTime * fps);
+      if (frame !== previousFrame) {
+        previousFrame = frame;
+        renderFrame(nextTime);
+      }
+      if (now - lastUiUpdate >= 1000 / 30 || nextTime >= totalDuration) {
+        currentTime = nextTime;
+        lastUiUpdate = now;
+      }
+      if (nextTime >= totalDuration) {
+        pause();
+        return;
       }
 
       animationFrameId = requestAnimationFrame(animate);
@@ -488,7 +574,9 @@
   }
 
   function pause() {
+    const wasPlaying = isPlaying;
     isPlaying = false;
+    if (wasPlaying) currentTime = playbackTime;
     audioElement?.pause();
     pauseVideoAssets(assets);
     if (animationFrameId) {
@@ -547,9 +635,18 @@
 
   function fitPreview() {
     if (!stage || !scene) return;
+    const previousScale = previewRenderScale();
     const rect = stage.getBoundingClientRect();
     const next = Math.min((rect.width - 72) / canvasWidth, (rect.height - 72) / canvasHeight, 1);
     zoom = Math.max(0.08, Number(next.toFixed(3)));
+    if (!isPlaying && Math.abs(previousScale - previewRenderScale()) > 0.01) {
+      requestAnimationFrame(() => renderFrame(currentTime));
+    }
+  }
+
+  function previewRenderScale(): number {
+    const pixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
+    return Math.min(1, Math.max(0.08, zoom * Math.min(pixelRatio, 1.5)));
   }
 
   function toggleFullscreen() {
@@ -634,20 +731,40 @@
   }
 
   async function handleAudioSelected(event: Event) {
-    const file = (event.currentTarget as HTMLInputElement).files?.[0];
+    const input = event.currentTarget as HTMLInputElement;
+    await importAudioFile(input.files?.[0]);
+    input.value = '';
+  }
+
+  async function handleAudioFileDrop(event: DragEvent) {
+    event.preventDefault();
+    isDraggingUpload = false;
+    await importAudioFile(event.dataTransfer?.files[0]);
+  }
+
+  async function importAudioFile(file: File | undefined) {
     if (!file || !ast) return;
-    if (file.size > 50 * 1024 * 1024) {
-      assetError = 'Audio files must be 50 MB or smaller.';
+    audioError = '';
+    if (!file.type.startsWith('audio/') && !/\.(aac|flac|m4a|mp3|ogg|opus|wav)$/i.test(file.name)) {
+      audioError = `${file.name} is not a supported audio file.`;
       return;
     }
+    if (file.size > 50 * 1024 * 1024) {
+      audioError = 'Audio files must be 50 MB or smaller.';
+      return;
+    }
+    const loadId = ++audioLoadId;
     const dataUrl = await readFileDataUrl(file);
+    if (loadId !== audioLoadId) return;
     if (audioUrl.startsWith('blob:')) URL.revokeObjectURL(audioUrl);
     audioUrl = dataUrl;
+    loadedAudioPath = dataUrl;
     audioName = file.name;
     audioDuration = 0;
     audioElement.src = audioUrl;
     audioElement.muted = projectAudioTrack?.muted ?? false;
     audioElement.load();
+    void loadAudioWaveform(file);
     ast.body = ast.body.filter((node) => node.type !== 'Audio');
     const insertAt = ast.body.findIndex(
       (node) => node.type === 'Import' || node.type === 'Track' || node.type === 'Element'
@@ -657,18 +774,20 @@
       path: dataUrl,
       properties: {},
     });
-    audioInput.value = '';
     code = serializeProgram(ast);
   }
 
   async function loadAudioFromPath(path: string) {
+    const loadId = ++audioLoadId;
     try {
       const response = await fetch(path);
       if (!response.ok) throw new Error('Failed to load audio');
       
       const blob = await response.blob();
-      if (audioUrl) URL.revokeObjectURL(audioUrl);
+      if (loadId !== audioLoadId) return;
+      if (audioUrl.startsWith('blob:')) URL.revokeObjectURL(audioUrl);
       audioUrl = URL.createObjectURL(blob);
+      loadedAudioPath = path;
       audioName = path.startsWith('data:audio/')
         ? 'Embedded audio'
         : path.substring(path.lastIndexOf('/') + 1);
@@ -678,17 +797,64 @@
         audioElement.src = audioUrl;
         audioElement.load();
       }
+      void loadAudioWaveform(blob);
     } catch (error) {
-      console.error('Failed to load audio:', error);
+      if (loadId === audioLoadId) console.error('Failed to load audio:', error);
     }
+  }
+
+  async function loadAudioWaveform(blob: Blob) {
+    const loadId = ++audioWaveformLoadId;
+    audioWaveformPath = '';
+    audioWaveformPeakCount = 0;
+    audioWaveformLoading = true;
+    let context: AudioContext | null = null;
+    try {
+      const source = await blob.arrayBuffer();
+      if (loadId !== audioWaveformLoadId) return;
+      context = new AudioContext();
+      const buffer = await context.decodeAudioData(source);
+      if (loadId !== audioWaveformLoadId) return;
+      audioDuration = buffer.duration;
+      const channels = Array.from(
+        { length: buffer.numberOfChannels },
+        (_, channel) => buffer.getChannelData(channel)
+      );
+      const peaks = await extractAudioPeaks(
+        channels,
+        waveformBucketCount(buffer.duration),
+        () => loadId !== audioWaveformLoadId
+      );
+      if (loadId !== audioWaveformLoadId) return;
+      audioWaveformPath = waveformPath(peaks);
+      audioWaveformPeakCount = peaks.length;
+    } catch (error) {
+      if (loadId === audioWaveformLoadId) {
+        console.warn('Could not generate audio waveform:', error);
+      }
+    } finally {
+      if (context) await context.close().catch(() => undefined);
+      if (loadId === audioWaveformLoadId) audioWaveformLoading = false;
+    }
+  }
+
+  function clearAudioWaveform() {
+    audioWaveformLoadId += 1;
+    audioWaveformPath = '';
+    audioWaveformPeakCount = 0;
+    audioWaveformLoading = false;
   }
 
   function removeAudio() {
     pause();
-    if (audioUrl) URL.revokeObjectURL(audioUrl);
+    audioLoadId += 1;
+    clearAudioWaveform();
+    if (audioUrl.startsWith('blob:')) URL.revokeObjectURL(audioUrl);
     audioUrl = '';
+    loadedAudioPath = '';
     audioName = '';
     audioDuration = 0;
+    audioPlayPromise = null;
     if (audioElement) audioElement.removeAttribute('src');
     
     // Remove audio from AST
@@ -788,22 +954,26 @@
     code = serializeProgram(ast);
   }
 
-  function syncAudio() {
+  function syncAudio(time = currentTime) {
     if (!audioUrl || !audioElement) return;
     audioElement.currentTime = Math.min(
-      Math.max(0, currentTime - (scene?.audioStart ?? 0)),
-      audioDuration || currentTime
+      Math.max(0, time - (scene?.audioStart ?? 0)),
+      audioDuration || time
     );
   }
 
-  function resumeAudioAtCurrentTime() {
+  function resumeAudioAtTime(time: number) {
     if (!audioUrl || !audioElement || !scene) return;
-    const localTime = currentTime - scene.audioStart;
+    const localTime = time - scene.audioStart;
     if (localTime < 0 || localTime >= (audioDuration || Number.POSITIVE_INFINITY)) return;
-    syncAudio();
-    if (audioElement.paused) {
-      audioElement.play().catch((error) => {
+    syncAudio(time);
+    if (audioElement.paused && !audioPlayPromise) {
+      const operation = audioElement.play().catch((error) => {
         console.warn('Audio playback failed (this is normal if no user interaction yet):', error.message);
+      });
+      audioPlayPromise = operation;
+      void operation.finally(() => {
+        if (audioPlayPromise === operation) audioPlayPromise = null;
       });
     }
   }
@@ -854,6 +1024,14 @@
     if (!node) return;
     node.properties = { ...node.properties, ...updates };
     code = serializeProgram(ast);
+  }
+
+  function nudgeSelectedElement(x: number, y: number) {
+    if (!selectedElement) return;
+    updateElementProperties(selectedElement.id, {
+      x: numericProperty(selectedElement, 'x', 0) + x,
+      y: numericProperty(selectedElement, 'y', 0) + y,
+    });
   }
 
   function handleCanvasPointerDown(event: PointerEvent) {
@@ -1029,6 +1207,20 @@
     dropTargetTrack = '';
   }
 
+  function handleAudioDragStart(event: DragEvent) {
+    draggingAudio = true;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', audioName);
+    }
+  }
+
+  function handleAudioDragEnd() {
+    draggingAudio = false;
+    dropTargetTime = null;
+    dropTargetTrack = '';
+  }
+
   async function handleAssetUpload(event: Event) {
     await importAssetFiles((event.currentTarget as HTMLInputElement).files);
     assetInput.value = '';
@@ -1149,10 +1341,10 @@
   }
 
   function handleTimelineDragOver(event: DragEvent) {
-    if (!draggingAsset) return;
+    if (!draggingAsset && !draggingAudio) return;
     event.preventDefault();
     if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = 'copy';
+      event.dataTransfer.dropEffect = draggingAudio ? 'move' : 'copy';
     }
 
     const timeline = event.currentTarget as HTMLElement;
@@ -1160,12 +1352,26 @@
     if (!rect) return;
     dropTargetTime = timelineTimeAt(event.clientX, rect);
     const track = (event.target as HTMLElement).closest<HTMLElement>('[data-track]')?.dataset['track'];
-    dropTargetTrack = track && !Number.isNaN(Number(track)) ? Number(track) : (track || 1);
+    if (draggingAudio) {
+      dropTargetTrack = projectAudioTrack?.id ?? 'legacy-audio';
+    } else {
+      dropTargetTrack = track && !Number.isNaN(Number(track)) ? Number(track) : (track || 1);
+    }
   }
 
   function handleTimelineDrop(event: DragEvent) {
     event.preventDefault();
-    if (!draggingAsset || !ast || dropTargetTime === null) return;
+    if (!ast || dropTargetTime === null) return;
+    if (draggingAudio) {
+      const node = ast.body.find((candidate): candidate is AudioNode => candidate.type === 'Audio');
+      if (node) {
+        node.properties = { ...node.properties, start: `${dropTargetTime.toFixed(3)}s` };
+        code = serializeProgram(ast);
+      }
+      handleAudioDragEnd();
+      return;
+    }
+    if (!draggingAsset) return;
     
     const assetName = draggingAsset.name;
     const frame = 1 / (scene?.canvas.fps ?? 60);
@@ -2395,7 +2601,15 @@
                   <span class="folder-title">Audio</span>
                 </div>
                 <div class="folder-content">
-                  <div class="asset-item">
+                  <div
+                    class="asset-item audio-asset"
+                    role="button"
+                    tabindex="0"
+                    draggable="true"
+                    aria-label={`Drag ${audioName || 'audio'} to the timeline`}
+                    on:dragstart={handleAudioDragStart}
+                    on:dragend={handleAudioDragEnd}
+                  >
                     <div class="asset-item-icon">
                       <Music2 size={16} />
                     </div>
@@ -2478,15 +2692,43 @@
           </div>
         </div>
         <div class="panel-content">
-          {#if audioName}
-            <div class="audio-item">
-              <Music2 size={18} />
-              <span>{audioName}</span>
-              <button class="icon-btn" on:click={removeAudio} title="Remove audio"><Trash2 size={14} /></button>
+          <div
+            class="media-dropzone"
+            class:drag-active={isDraggingUpload}
+            role="region"
+            aria-label="Import audio by dropping a file"
+            on:dragenter={handleAssetFileDrag}
+            on:dragover|preventDefault={handleAssetFileDrag}
+            on:dragleave={handleAssetFileDragLeave}
+            on:drop={handleAudioFileDrop}
+          >
+            {#if audioError}<p class="asset-error">{audioError}</p>{/if}
+            <div class="media-drop-prompt">
+              <button type="button" class="import-media-button" on:click={() => audioInput.click()}>
+                <Upload size={15} />
+                Import audio
+              </button>
+              <span>or drag & drop from your device</span>
+              <small>Audio files up to 50 MB</small>
             </div>
-          {:else}
-            <p class="empty-state">No audio attached</p>
-          {/if}
+            {#if audioName}
+              <div
+                class="audio-item audio-asset"
+                role="button"
+                tabindex="0"
+                draggable="true"
+                aria-label={`Drag ${audioName} to the timeline`}
+                on:dragstart={handleAudioDragStart}
+                on:dragend={handleAudioDragEnd}
+              >
+                <Music2 size={18} />
+                <span>{audioName}</span>
+                <button class="icon-btn" on:click={removeAudio} title="Remove audio"><Trash2 size={14} /></button>
+              </div>
+            {:else}
+              <p class="empty-state">Imported audio will appear on the timeline.</p>
+            {/if}
+          </div>
         </div>
       {:else if activeNavTab === 'text'}
         <div class="panel-header">
@@ -3123,10 +3365,10 @@
     ><span></span></button>
     <div class="timeline-toolbar">
       <div class="playback-controls">
-        <button on:click={reset} class="control-btn" title="Go to start">
+        <button on:click={reset} class="control-btn" title="Go to start (Home)">
           <SkipBack size={17} />
         </button>
-        <button on:click={isPlaying ? pause : play} class="control-btn play-btn" title={isPlaying ? 'Pause' : 'Play'}>
+        <button on:click={isPlaying ? pause : play} class="control-btn play-btn" title={isPlaying ? 'Pause (Space)' : 'Play (Space)'}>
           {#if isPlaying}<Pause size={19} />{:else}<Play size={19} />{/if}
         </button>
         <span class="timecode">{formatPreciseTime(currentTime)}</span>
@@ -3147,11 +3389,11 @@
           <button class="timeline-command" on:click={() => audioInput.click()} title="Attach audio"><Upload size={14} /> Audio</button>
         {/if}
         {#if selectedElement || selectedClip}
-          <button class="icon-btn danger-btn" on:click={deleteSelectedElement} title="Delete selected layer"><Trash2 size={14} /></button>
+          <button class="icon-btn danger-btn" on:click={deleteSelectedElement} title="Delete selected layer (Delete)"><Trash2 size={14} /></button>
         {/if}
         <button class="icon-btn" on:click={undoEditor} disabled={editorHistory.past.length === 0} title="Undo (Ctrl/Cmd+Z)"><Undo2 size={14} /></button>
         <button class="icon-btn" on:click={redoEditor} disabled={editorHistory.future.length === 0} title="Redo (Ctrl/Cmd+Shift+Z)"><Redo2 size={14} /></button>
-        <button class="icon-btn" on:click={splitSelectedClip} disabled={!((selectedClip && currentTime > selectedClip.start && currentTime < selectedClip.start + selectedClip.duration) || (selectedElement && currentTime > timelineRange(selectedElement.id).start && currentTime < timelineRange(selectedElement.id).end))} title="Split selected clip at playhead"><Scissors size={14} /></button>
+        <button class="icon-btn" on:click={splitSelectedClip} disabled={!((selectedClip && currentTime > selectedClip.start && currentTime < selectedClip.start + selectedClip.duration) || (selectedElement && currentTime > timelineRange(selectedElement.id).start && currentTime < timelineRange(selectedElement.id).end))} title="Split selected clip at playhead (S)"><Scissors size={14} /></button>
         <button class="icon-btn" class:active={snapEnabled} on:click={() => snapEnabled = !snapEnabled} title={snapEnabled ? 'Disable edge snapping' : 'Enable edge snapping'}><Magnet size={15} /></button>
         <button on:click={() => setTimelineZoom(timelineZoom / 1.25)} class="icon-btn" title="Timeline zoom out"><Minus size={15} /></button>
         <span class="timeline-zoom-value">{Math.round(timelineZoom * 100)}%</span>
@@ -3162,8 +3404,8 @@
     <div 
       bind:this={timelineScroll}
       class="timeline-scroll" 
-      style={`--timeline-content-width: ${timelineContentWidth}px`}
-      class:drop-target={draggingAsset !== null}
+      style={`--timeline-content-width: ${timelineContentWidth}px; --playhead-position: ${timelinePercent(currentTime)}%`}
+      class:drop-target={draggingAsset !== null || draggingAudio}
       role="region"
       aria-label="Timeline tracks"
       on:dragover={handleTimelineDragOver}
@@ -3177,7 +3419,7 @@
           {#each timelineTicks as tick}
             <span class="ruler-tick" style={`left: ${timelinePercent(tick)}%`}>{formatTime(tick)}</span>
           {/each}
-          <span class="playhead-marker" style={`left: ${timelinePercent(currentTime)}%`}></span>
+          <span class="playhead-marker"></span>
           {#if dropTargetTime !== null}
             <span class="drop-indicator" style={`left: ${timelinePercent(dropTargetTime)}%`}></span>
           {/if}
@@ -3266,7 +3508,6 @@
                 on:click|stopPropagation={addKeyframeAtPlayhead}
               >+</button>
             {/if}
-            <span class="playhead" style={`left: ${timelinePercent(currentTime)}%`}></span>
           </div>
         </div>
       {/each}
@@ -3314,8 +3555,15 @@
                 {/if}
               {/if}
               {#if clipTrack.metadata?.id === projectAudioTrack?.id && audioName}
-                <span class="clip audio-clip" style={`left: ${timelinePercent(scene?.audioStart ?? 0)}%; width: ${timelinePercent(Math.min(audioDuration || totalDuration, Math.max(0, totalDuration - (scene?.audioStart ?? 0))))}%; top: 6px`}>
-                  <span class="clip-text">{audioName}</span>
+                <span class="clip audio-clip" class:muted={projectAudioTrack?.muted} style={`left: ${timelinePercent(scene?.audioStart ?? 0)}%; width: ${timelinePercent(audioClipDuration)}%; top: 6px`}>
+                  <span class="audio-waveform" class:loading={audioWaveformLoading} aria-hidden="true">
+                    {#if audioWaveformPath}
+                      <svg viewBox={`0 0 ${visibleWaveformPeaks} 24`} preserveAspectRatio="none">
+                        <path d={audioWaveformPath}></path>
+                      </svg>
+                    {/if}
+                  </span>
+                  <span class="clip-text audio-clip-label">{audioName}</span>
                   <button type="button" class="clip-select" on:pointerdown={moveTimelineAudio} aria-label={`Move audio ${audioName}`}></button>
                 </span>
               {/if}
@@ -3403,7 +3651,6 @@
                   {boundary.type ? '×' : '+'}
                 </button>
               {/each}
-              <span class="playhead" style={`left: ${timelinePercent(currentTime)}%`}></span>
             </div>
           </div>
       {/each}
@@ -3717,7 +3964,8 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .media-dropzone.drag-active {
+    .media-dropzone.drag-active,
+    .audio-waveform.loading {
       animation: none;
     }
   }
@@ -3889,6 +4137,14 @@
     background: #0d0e10;
     color: #d8dce2;
     font-size: 13px;
+  }
+
+  .audio-asset {
+    cursor: grab;
+  }
+
+  .audio-asset:active {
+    cursor: grabbing;
   }
 
   /* Panel Tabs */
@@ -5128,6 +5384,7 @@
     z-index: 2;
     top: 0;
     bottom: -1px;
+    left: var(--playhead-position);
     width: 2px;
     background: #f1f2f4;
     transform: translateX(-50%);
@@ -5406,6 +5663,58 @@
   .audio-clip {
     border-color: #725d86;
     background: #4e405d;
+    overflow: hidden;
+  }
+
+  .audio-waveform {
+    position: absolute;
+    inset: 2px;
+    color: rgba(224, 196, 255, 0.72);
+    opacity: 0.9;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .audio-waveform::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 0;
+    left: 0;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.24;
+  }
+
+  .audio-waveform svg {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .audio-waveform path {
+    fill: currentColor;
+  }
+
+  .audio-waveform.loading {
+    animation: waveform-pulse 0.9s ease-in-out infinite alternate;
+  }
+
+  .audio-clip.muted .audio-waveform {
+    opacity: 0.28;
+  }
+
+  .audio-clip-label {
+    z-index: 1;
+    text-shadow: 0 1px 3px rgba(24, 16, 32, 0.95);
+  }
+
+  @keyframes waveform-pulse {
+    to {
+      opacity: 0.35;
+    }
   }
 
   .mask-select { min-height: 34px; width: 100%; }
@@ -5481,11 +5790,13 @@
   .keyframe-controls .number-input-wrapper { width: 84px; }
   .easing-input { margin-top: 8px; min-height: 32px; }
 
-  .playhead {
+  .track-lane::after {
+    content: '';
     position: absolute;
     z-index: 2;
     top: 0;
     bottom: 0;
+    left: var(--playhead-position);
     width: 1px;
     background: #f1f2f4;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.45);

--- a/src/ui/editor-shortcuts.ts
+++ b/src/ui/editor-shortcuts.ts
@@ -1,0 +1,38 @@
+export type EditorShortcut =
+  | 'clear-selection'
+  | 'delete-selection'
+  | 'nudge-down'
+  | 'nudge-left'
+  | 'nudge-right'
+  | 'nudge-up'
+  | 'redo'
+  | 'reset-playhead'
+  | 'save'
+  | 'split'
+  | 'toggle-playback'
+  | 'undo';
+
+type ShortcutEvent = Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>;
+
+export function editorShortcut(event: ShortcutEvent, interactive = false): EditorShortcut | null {
+  const command = event.ctrlKey || event.metaKey;
+  const key = event.key.toLowerCase();
+
+  if (command) {
+    if (!event.altKey && !event.shiftKey && key === 's') return 'save';
+    if (!event.altKey && !interactive && key === 'z') return event.shiftKey ? 'redo' : 'undo';
+    return null;
+  }
+  if (interactive || event.altKey) return null;
+
+  if (event.key === ' ') return 'toggle-playback';
+  if (event.key === 'Delete' || event.key === 'Backspace') return 'delete-selection';
+  if (event.key === 'ArrowLeft') return 'nudge-left';
+  if (event.key === 'ArrowRight') return 'nudge-right';
+  if (event.key === 'ArrowUp') return 'nudge-up';
+  if (event.key === 'ArrowDown') return 'nudge-down';
+  if (event.key === 'Home') return 'reset-playhead';
+  if (event.key === 'Escape') return 'clear-selection';
+  if (!event.shiftKey && key === 's') return 'split';
+  return null;
+}

--- a/src/ui/timeline-viewport.ts
+++ b/src/ui/timeline-viewport.ts
@@ -18,6 +18,16 @@ export function quantizeTimelineTime(time: number, duration: number, fps: number
   return Math.min(safeDuration, Math.round(clamped * safeFps) / safeFps);
 }
 
+export function playbackTimeFromClock(
+  startTime: number,
+  startedAtMs: number,
+  nowMs: number,
+  duration: number
+): number {
+  const elapsed = Math.max(0, nowMs - startedAtMs) / 1000;
+  return Math.min(Math.max(0, duration), Math.max(0, startTime) + elapsed);
+}
+
 export function timelineContentWidth(
   duration: number,
   zoom: number,

--- a/tests/animation/evaluator-density.test.ts
+++ b/tests/animation/evaluator-density.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateScene } from '../../src/animation/evaluator';
+import { parseMotion } from '../../src/language/parser';
+import { buildSceneGraph } from '../../src/scene/scene-graph';
+
+describe('dense scene evaluation', () => {
+  it('reuses prepared scene data without changing frame results', () => {
+    const layers = Array.from(
+      { length: 120 },
+      (_, index) => `
+        text layer${index} {
+          value "Layer ${index}"
+          x ${index}
+          y 0
+        }
+
+        animate layer${index} {
+          from { y 0 }
+          to { y 100 }
+          duration 1s
+          easing linear
+        }
+      `
+    ).join('\n');
+    const scene = buildSceneGraph(parseMotion(`canvas { duration 10s }\n${layers}`));
+
+    const middle = evaluateScene(scene, 0.5);
+    const end = evaluateScene(scene, 1);
+
+    expect(middle.elements).toHaveLength(120);
+    expect(middle.elements[80]?.render).toMatchObject({ x: 80, y: 50 });
+    expect(end.elements[80]?.render).toMatchObject({ x: 80, y: 100 });
+  });
+});

--- a/tests/assets/video-assets.test.ts
+++ b/tests/assets/video-assets.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { videoSourceTime } from '../../src/assets/asset-loader';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  synchronizeVideoAssets,
+  videoSourceTime,
+  type LoadedAsset,
+} from '../../src/assets/asset-loader';
 import { assetType } from '../../src/scene/scene-graph';
+import type { EvaluatedScene } from '../../src/types/scene';
 
 describe('video assets', () => {
   it('classifies MP4/WebM paths, query URLs, and data URLs', () => {
@@ -16,5 +21,20 @@ describe('video assets', () => {
     expect(videoSourceTime(12, 10, 1)).toBeCloseTo(8.999);
     expect(videoSourceTime(-2, 10, 0)).toBe(0);
     expect(videoSourceTime(Number.NaN, 10, 0)).toBe(0);
+  });
+
+  it('does not scan and pause videos that were never active', async () => {
+    const pause = vi.fn();
+    const video = {
+      motionlyType: 'video',
+      motionlyDuration: 10,
+      pause,
+    } as unknown as LoadedAsset;
+    const assets = new Map([['unused', video]]);
+    const frame = { elements: [] } as unknown as EvaluatedScene;
+
+    await synchronizeVideoAssets(frame, assets, { playing: true });
+
+    expect(pause).not.toHaveBeenCalled();
   });
 });

--- a/tests/ui/audio-waveform.test.ts
+++ b/tests/ui/audio-waveform.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractAudioPeaks,
+  MAX_WAVEFORM_BUCKETS,
+  waveformBucketCount,
+  waveformPath,
+} from '../../src/ui/audio-waveform';
+
+describe('audio waveform', () => {
+  it('extracts normalized peaks across audio channels', async () => {
+    const peaks = await extractAudioPeaks(
+      [new Float32Array([-0.25, 0.5, -1, 0.75]), new Float32Array([-0.5, 0.25, -0.75, 1])],
+      2
+    );
+
+    expect(peaks).toEqual([
+      { min: -0.5, max: 0.5 },
+      { min: -1, max: 1 },
+    ]);
+  });
+
+  it('handles silence, cancellation, and bounded long files', async () => {
+    expect(await extractAudioPeaks([new Float32Array(8)], 4)).toEqual([
+      { min: 0, max: 0 },
+      { min: 0, max: 0 },
+      { min: 0, max: 0 },
+      { min: 0, max: 0 },
+    ]);
+    expect(await extractAudioPeaks([new Float32Array([1])], 1, () => true)).toEqual([]);
+    expect(waveformBucketCount(0)).toBe(64);
+    expect(waveformBucketCount(10_000)).toBe(MAX_WAVEFORM_BUCKETS);
+  });
+
+  it('creates one scalable filled SVG path', () => {
+    const path = waveformPath([
+      { min: -1, max: 1 },
+      { min: -0.5, max: 0.5 },
+    ]);
+
+    expect(path).toMatch(/^M/);
+    expect(path).toContain('L');
+    expect(path).toMatch(/Z$/);
+  });
+});

--- a/tests/ui/editor-shortcuts.test.ts
+++ b/tests/ui/editor-shortcuts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { editorShortcut } from '../../src/ui/editor-shortcuts';
+
+const key = (
+  value: string,
+  overrides: Partial<Parameters<typeof editorShortcut>[0]> = {},
+  interactive = false
+) =>
+  editorShortcut(
+    {
+      altKey: false,
+      ctrlKey: false,
+      key: value,
+      metaKey: false,
+      shiftKey: false,
+      ...overrides,
+    },
+    interactive
+  );
+
+describe('editor shortcuts', () => {
+  it('maps the common editor actions', () => {
+    expect(key(' ')).toBe('toggle-playback');
+    expect(key('Delete')).toBe('delete-selection');
+    expect(key('ArrowLeft')).toBe('nudge-left');
+    expect(key('s')).toBe('split');
+    expect(key('Home')).toBe('reset-playhead');
+    expect(key('Escape')).toBe('clear-selection');
+    expect(key('s', { ctrlKey: true })).toBe('save');
+    expect(key('z', { metaKey: true })).toBe('undo');
+    expect(key('z', { metaKey: true, shiftKey: true })).toBe('redo');
+  });
+
+  it('leaves typing and focused controls alone except for save', () => {
+    expect(key(' ', {}, true)).toBeNull();
+    expect(key('Backspace', {}, true)).toBeNull();
+    expect(key('z', { ctrlKey: true }, true)).toBeNull();
+    expect(key('s', { ctrlKey: true }, true)).toBe('save');
+  });
+});

--- a/tests/ui/timeline-viewport.test.ts
+++ b/tests/ui/timeline-viewport.test.ts
@@ -6,6 +6,7 @@ import {
   timelineTimeAtX,
   timelineXAtTime,
   quantizeTimelineTime,
+  playbackTimeFromClock,
 } from '../../src/ui/timeline-viewport';
 
 describe('timeline viewport math', () => {
@@ -28,5 +29,10 @@ describe('timeline viewport math', () => {
   it('quantizes playhead time to exact frames', () => {
     expect(quantizeTimelineTime(1.234, 5, 30)).toBe(37 / 30);
     expect(quantizeTimelineTime(9, 5, 60)).toBe(5);
+  });
+
+  it('keeps playback on the absolute clock when frames are delayed', () => {
+    expect(playbackTimeFromClock(2, 1_000, 2_750, 10)).toBe(3.75);
+    expect(playbackTimeFromClock(9, 1_000, 5_000, 10)).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary

  - Improved long-project preview performance through cached scene evaluation, display-scale rendering, and reduced video synchronization work.
  - Added keyboard shortcuts for playback, save, undo/redo, deletion, splitting, and element movement.
  - Added audio importing, draggable timeline placement, and waveform rendering.

  ## Testing

  - npm test -- --run — 169 tests passed across 36 test files.
  - npm run type-check — passed.
  - npm run build — passed.
  - Browser smoke-tested the editor layout.

  ## Risk

  - Scene, animation, and SVG caches rely on stable object identity.
  - Video synchronization stores pending play/seek operations on loaded video elements.
  - Preview rendering may appear softer at low editor zoom; export resolution is unaffected.
  - Audio waveform generation decodes the complete file in memory, currently limited by the 50 MB import cap.

  ## Checklist

  - [x] I ran npm test.
  - [x] I kept the change scoped and readable.
  - [ ] I updated docs for syntax, preset, export, or public behavior changes.
  - [ ] I did not mutate imported assets or add hidden renderer state.