### PR TITLE
feat: integrate rayucode as a supported agent provider

### DIFF
--- a/bin/motionly.js
+++ b/bin/motionly.js
@@ -26,6 +26,7 @@ const PROVIDERS = {
   gemini: '.gemini/skills/motionly/SKILL.md',
   opencode: '.opencode/skills/motionly/SKILL.md',
   kiro: '.kiro/skills/motionly/SKILL.md',
+  rayu: '.rayu/skills/motionly/SKILL.md',
 };
 
 const AGENT_LABELS = {
@@ -34,6 +35,7 @@ const AGENT_LABELS = {
   gemini: 'Gemini CLI',
   opencode: 'opencode',
   kiro: 'Kiro',
+  rayu: 'RAYU',
 };
 
 const MIME = {
@@ -434,7 +436,7 @@ function printHelp() {
   npx @coppsary/motionly init <folder> --skip-skills      Create a project without agent skills
   npx @coppsary/motionly skills add                       Install agent skills into an existing project
   npx @coppsary/motionly skills add --all
-  npx @coppsary/motionly skills add --provider <codex|claude|gemini|opencode|kiro>
+  npx @coppsary/motionly skills add --provider <codex|claude|gemini|opencode|kiro|rayu>
   npx @coppsary/motionly dev [project-folder]             Reopen and edit a local project
 
 Options: --scope <project|global>, --port <number>, --no-open`);

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -7,7 +7,7 @@ Read the installed `motionly` skill before creating or substantially editing `pr
 ## Agent Skill
 
 Installing the skill placed it at `.<agent>/skills/motionly/SKILL.md` (Codex uses
-`.agents/`, plus `.claude/`, `.gemini/`, `.opencode/`, or `.kiro/`). That file is the
+`.agents/`, plus `.claude/`, `.gemini/`, `.opencode/`, `.kiro/`, or `.rayu/`). That file is the
 quick contract; a full reference library sits beside it under `references/` (`llms.txt`
 index plus focused skills: `motion-dsl`, `svg`, `animation`, `easing`, `camera`, `composition`,
 `typography`, `transitions`, `timeline`, `assets`, `rendering`, `templates`).

--- a/tests/cli/local-workflow.test.ts
+++ b/tests/cli/local-workflow.test.ts
@@ -38,6 +38,7 @@ describe('local CLI workflow', () => {
       '.agents/skills/motionly/SKILL.md',
       '.gemini/skills/motionly/SKILL.md',
       '.kiro/skills/motionly/SKILL.md',
+      '.rayu/skills/motionly/SKILL.md',
     ]) {
       expect((await stat(join(workspace, path))).isFile()).toBe(true);
     }
@@ -71,6 +72,7 @@ describe('local CLI workflow', () => {
       '.agents/skills/motionly/SKILL.md',
       '.gemini/skills/motionly/SKILL.md',
       '.kiro/skills/motionly/SKILL.md',
+      '.rayu/skills/motionly/SKILL.md',
     ]) {
       expect((await stat(join(home, path))).isFile()).toBe(true);
     }


### PR DESCRIPTION
Add RAYU to the provider/label maps so `motionly init --provider rayu` and `motionly skills add --provider rayu` install the Motionly skill into `.rayu/skills/motionly/`, which RAYU auto-discovers at both project and user levels. Update the scaffolded project's AGENTS.md and the CLI install-path tests to cover the new provider.

Verified end-to-end: RAYU's real skill loader discovers the installed skill and can invoke it to author a valid .motion file; full vitest suite passes (177/177).

## Summary

-

## Testing

-

## Visual Evidence

Add screenshots, GIFs, or short videos for renderer, UI, or `.motion` scene changes.

## Risk

-

## Checklist

- [x] I ran `npm test`.
- [x] I kept the change scoped and readable.
- [x] I updated docs for syntax, preset, export, or public behavior changes.
- [x] I did not mutate imported assets or add hidden renderer state.
