### PR TITLE
fix independent keyframes and scale synchronization

### DIFF
--- a/src/animation/evaluator.ts
+++ b/src/animation/evaluator.ts
@@ -296,45 +296,32 @@ function applyKeyframes(
 ): PropertyMap {
   if (keyframes.length === 0) return state;
 
-  const firstFrame = keyframes[0];
-  const lastFrame = keyframes[keyframes.length - 1];
-
-  if (!firstFrame || !lastFrame) return state;
-
-  if (progress <= firstFrame.offset) {
-    return { ...state, ...firstFrame.properties };
-  }
-
-  if (progress >= lastFrame.offset) {
-    return { ...state, ...lastFrame.properties };
-  }
-
   const next: PropertyMap = { ...state };
-  let left = firstFrame;
-  let right = lastFrame;
-
-  for (let index = 0; index < keyframes.length - 1; index += 1) {
-    const current = keyframes[index];
-    const nextFrame = keyframes[index + 1];
-
-    if (!current || !nextFrame) continue;
-
-    if (progress >= current.offset && progress <= nextFrame.offset) {
-      left = current;
-      right = nextFrame;
-      break;
-    }
-  }
-
-  const span = right.offset - left.offset || 1;
-  const segmentEasing = right.easing ?? easing;
-  const local = ease((progress - left.offset) / span, segmentEasing);
-  const keys = new Set([...Object.keys(left.properties), ...Object.keys(right.properties)]);
+  const keys = new Set(keyframes.flatMap((frame) => Object.keys(frame.properties)));
 
   for (const key of keys) {
-    const from = left.properties[key] ?? state[key] ?? 0;
-    const to = right.properties[key] ?? state[key] ?? 0;
-    next[key] = interpolateValue(from, to, local);
+    const propertyFrames = keyframes.filter((frame) => key in frame.properties);
+    const first = propertyFrames[0];
+    const last = propertyFrames[propertyFrames.length - 1];
+    if (!first || !last) continue;
+    if (progress <= first.offset || first === last) {
+      next[key] = first.properties[key]!;
+      continue;
+    }
+    if (progress >= last.offset) {
+      next[key] = last.properties[key]!;
+      continue;
+    }
+
+    for (let index = 0; index < propertyFrames.length - 1; index += 1) {
+      const left = propertyFrames[index];
+      const right = propertyFrames[index + 1];
+      if (!left || !right || progress < left.offset || progress > right.offset) continue;
+      const span = right.offset - left.offset || 1;
+      const local = ease((progress - left.offset) / span, right.easing ?? easing);
+      next[key] = interpolateValue(left.properties[key]!, right.properties[key]!, local);
+      break;
+    }
   }
 
   return next;

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -22,7 +22,18 @@
   import type { Asset, Clip, Element, EvaluatedElement, EvaluatedScene, Scene, Track } from '../../types/scene';
   import { combinePersistentTrackRows, packClipTrackLanes, packTimelineLanes } from '../timeline-lanes';
   import { alignRect, snapRect, type Alignment, type SnapGuides } from '../canvas-geometry';
-  import { moveKeyframe, removeKeyframe, seedKeyframes, setKeyframeEasing, upsertKeyframe } from '../keyframe-editing';
+  import {
+    animatedProperties,
+    hasKeyframeProperties,
+    keyframeOffsetAtTime,
+    mergeCoincidentKeyframes,
+    moveKeyframe,
+    removeKeyframe,
+    removeKeyframeProperties,
+    seedKeyframes,
+    setKeyframeEasing,
+    upsertKeyframe,
+  } from '../keyframe-editing';
   import { placeMediaClip, splitClip, type ClipTiming } from '../clip-timing';
   import {
     adjacentClipBoundaries,
@@ -59,6 +70,27 @@
   import './motion-editor/editor-shell.css';
   import './motion-editor/editor-theme.css';
 
+  const TIMING_PROPERTIES = new Set([
+    'start',
+    'duration',
+    'delay',
+    'track',
+    'mediaTime',
+    'mediaTrimOut',
+    'mediaVolume',
+  ]);
+  const DEFAULT_KEYFRAME_PROPERTIES = [
+    'x',
+    'y',
+    'scale',
+    'rotation',
+    'opacity',
+    'blur',
+    'size',
+    'color',
+    'fill',
+  ];
+
   export let code = '';
   export let onSave: () => void | Promise<void> = () => undefined;
   let canvas: HTMLCanvasElement;
@@ -80,8 +112,8 @@
   let totalDuration = 5;
   let animationFrameId: number | null = null;
   let dragState:
-    | { mode: 'move'; id: string; offsetX: number; offsetY: number; startX: number; startY: number }
-    | { mode: 'resize'; id: string; centerX: number; centerY: number; startDistance: number; startScale: number }
+    | { mode: 'move'; id: string; visualId: string; offsetX: number; offsetY: number; startX: number; startY: number }
+    | { mode: 'resize'; id: string; visualId: string; centerX: number; centerY: number; startDistance: number; startScale: number }
     | null = null;
   let snapGuides: SnapGuides = { vertical: null, horizontal: null };
   // Live ghost preview for dragging a clip or element layer on the timeline.
@@ -101,6 +133,9 @@
       }
     | null = null;
   let selectedKeyframeOffset: number | null = null;
+  let animatedPropertyNames: string[] = [];
+  let selectedKeyframeMarkerList: { offset: number; easing?: string; properties: string[] }[] = [];
+  let selectedAnimationTargetId = '';
   let moreOptionsOpen = false;
   let showCodeEditor = false;
   let selectedElementId = '';
@@ -151,6 +186,8 @@
   let deleteToastTimer: ReturnType<typeof setTimeout> | null = null;
   let deleteUndoSource: string | null = null;
   let deleteResultSource: string | null = null;
+  let keyframeNotice = '';
+  let keyframeNoticeTimer: ReturnType<typeof setTimeout> | null = null;
 
 
 
@@ -165,7 +202,7 @@
     requestAnimationFrame(fitPreview);
     
     const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
+      const target = e.target instanceof Element ? e.target : null;
       const interactive = Boolean(target?.closest(
         'input, textarea, select, button, a, [contenteditable="true"], [role="button"], [role="slider"]'
       ));
@@ -190,7 +227,8 @@
           else play();
           break;
         case 'delete-selection':
-          deleteSelectedElement();
+          if (selectedKeyframeOffset !== null) deleteSelectedKeyframe();
+          else deleteSelectedElement();
           break;
         case 'duplicate-selection':
           duplicateSelected();
@@ -233,6 +271,7 @@
       audioWaveformLoadId += 1;
       if (audioUrl) URL.revokeObjectURL(audioUrl);
       if (deleteToastTimer) clearTimeout(deleteToastTimer);
+      if (keyframeNoticeTimer) clearTimeout(keyframeNoticeTimer);
       window.removeEventListener('keydown', handleKeyDown);
     };
   });
@@ -335,8 +374,13 @@
       currentFrame?.elements.find((element) => element.id === selectedClip?.id) ??
       null
     : null;
+  $: selectedAnimationTargetId = selectedElement?.id ?? selectedClip?.assetName ?? '';
   $: selectedAnimation =
-    scene?.animations.find((animation) => animation.target === selectedElement?.id) ?? null;
+    scene?.animations.find((animation) => animation.target === selectedAnimationTargetId) ?? null;
+  $: animatedPropertyNames =
+    code && selectedAnimationTargetId ? selectedAnimatedProperties() : [];
+  $: selectedKeyframeMarkerList =
+    code && selectedAnimationTargetId ? selectedKeyframeMarkers() : [];
   $: keyframeDragDelta =
     clipDrag?.kind === 'element' && clipDrag.id === selectedElementId
       ? clipDrag.ghostStart - timelineRange(clipDrag.id).start
@@ -1039,18 +1083,62 @@
 
 
 
+  function selectedAnimationTarget(): string {
+    return selectedAnimationTargetId;
+  }
+
+  function selectedEvaluatedElement(): EvaluatedElement | Element | null {
+    const id = selectedClip?.id ?? selectedElement?.id;
+    return currentFrame?.elements.find((element) => element.id === id) ??
+      selectedElement ??
+      selectedClipElement;
+  }
+
   function updateElementProperty(key: string, value: string | number | boolean) {
+    updateElementProperties(selectedAnimationTarget(), { [key]: value });
+  }
+
+  function updateElementProperties(
+    elementId: string,
+    updates: Record<string, string | number | boolean>
+  ) {
     if (!ast) return;
-    const target = selectedElement?.id ?? selectedClip?.assetName;
-    if (!target) return;
-    const node = ensureAssetElement(target);
-    if (!node) return;
-    node.properties = { ...node.properties, [key]: value };
+    const element = ensureAssetElement(elementId);
+    if (!element) return;
+    const animated = Object.fromEntries(
+      Object.entries(updates).filter(([key]) => isPropertyAnimated([key]))
+    );
+    const staticUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([key]) => !(key in animated))
+    );
+    if (Object.keys(staticUpdates).length) {
+      element.properties = { ...element.properties, ...staticUpdates };
+    }
+    if (Object.keys(animated).length) {
+      const animation = materializeSelectedAnimation();
+      if (animation) {
+        ensureSeededKeyframes(animation);
+        const offset = selectedAnimationOffset(animation);
+        animation.keyframes = upsertKeyframe(
+          animation.keyframes ?? [],
+          offset,
+          animated,
+          selectedKeyframeTolerance(animation)
+        );
+        animation.from = {};
+        animation.to = {};
+        selectedKeyframeOffset = offset;
+      }
+    }
     code = serializeProgram(ast);
   }
 
-  function selectedVisualProperty(key: string, fallback: number): number {
-    return numericProperty(selectedElement ?? selectedClipElement, key, fallback);
+  function selectedVisualProperty(key: string, fallback: number, _time = currentTime): number {
+    return numericProperty(selectedEvaluatedElement(), key, fallback);
+  }
+
+  function selectedVisualStringProperty(key: string, fallback: string): string {
+    return stringProperty(selectedEvaluatedElement(), key, fallback);
   }
 
   function handlePropertyScrubKey(event: KeyboardEvent, key: string, fallback: number, minimum = Number.NEGATIVE_INFINITY) {
@@ -1124,16 +1212,6 @@
     code = serializeProgram(ast);
   }
 
-  function updateElementProperties(elementId: string, updates: Record<string, string | number | boolean>) {
-    if (!ast) return;
-    const node = ast.body.find(
-      (item): item is ElementNode => item.type === 'Element' && item.name === elementId
-    );
-    if (!node) return;
-    node.properties = { ...node.properties, ...updates };
-    code = serializeProgram(ast);
-  }
-
   function nudgeSelectedElement(x: number, y: number) {
     if (!selectedElement) return;
     updateElementProperties(selectedElement.id, {
@@ -1160,9 +1238,11 @@
         if (corners.some(([x, y]) => Math.hypot(point.x - x, point.y - y) <= handleRadius)) {
           const centerX = bounds.x + bounds.width / 2;
           const centerY = bounds.y + bounds.height / 2;
+          const visualId = selectedClip?.id ?? selectedVisual.id;
           dragState = {
             mode: 'resize',
-            id: selectedElement?.id ?? selectedClip?.assetName ?? selectedVisual.id,
+            id: selectedAnimationTarget() || selectedVisual.id,
+            visualId,
             centerX,
             centerY,
             startDistance: Math.max(1, Math.hypot(point.x - centerX, point.y - centerY)),
@@ -1183,12 +1263,16 @@
     pause();
     const targetId = stringProperty(element, 'textGroup', element.id);
     selectElement(targetId, false);
-    const target = scene.elements.find((item) => item.id === targetId);
+    const target =
+      currentFrame?.elements.find((item) => item.id === targetId) ??
+      scene.elements.find((item) => item.id === targetId);
     if (!target) return;
+    const sourceTarget = scene.clips.find((clip) => clip.id === targetId)?.assetName ?? targetId;
     const center = elementCenter(target);
     dragState = {
       mode: 'move',
-      id: targetId,
+      id: sourceTarget,
+      visualId: targetId,
       offsetX: point.x - center.x,
       offsetY: point.y - center.y,
       startX: numericProperty(target, 'x', 0),
@@ -1200,11 +1284,13 @@
   function handleCanvasPointerMove(event: PointerEvent) {
     if (!dragState || !scene) return;
     const point = pointerToCanvas(event);
-    const element = scene.elements.find((item) => item.id === dragState?.id);
+    const element =
+      currentFrame?.elements.find((item) => item.id === dragState?.visualId) ??
+      scene.elements.find((item) => item.id === dragState?.visualId);
     if (!element) return;
     if (dragState.mode === 'resize') {
       const distance = Math.hypot(point.x - dragState.centerX, point.y - dragState.centerY);
-      updateElementProperties(element.id, { scale: Number(Math.max(0.05, dragState.startScale * distance / dragState.startDistance).toFixed(3)) });
+      updateElementProperties(dragState.id, { scale: Number(Math.max(0.05, dragState.startScale * distance / dragState.startDistance).toFixed(3)) });
       return;
     }
     const centered = isCentered(element);
@@ -1235,7 +1321,7 @@
     snapGuides = snapped.guides;
     nextX += snapped.rect.x - proposedBounds.x;
     nextY += snapped.rect.y - proposedBounds.y;
-    updateElementProperties(element.id, { x: Math.round(nextX), y: Math.round(nextY) });
+    updateElementProperties(dragState.id, { x: Math.round(nextX), y: Math.round(nextY) });
   }
 
   function handleCanvasPointerUp(event: PointerEvent) {
@@ -2259,9 +2345,10 @@
   }
 
   function selectedAnimationAst(): AnimationNode | null {
-    if (!ast || !selectedElement) return null;
+    const target = selectedAnimationTarget();
+    if (!ast || !target) return null;
     return ast.body.find(
-      (node): node is AnimationNode => node.type === 'Animation' && node.target === selectedElement.id
+      (node): node is AnimationNode => node.type === 'Animation' && node.target === target
     ) ?? null;
   }
 
@@ -2271,14 +2358,23 @@
   // their real keyframes; preset-driven animations (animation/textAnimation)
   // surface their compiled start/end (or keyframes) so every animated element
   // shows editable keyframes.
-  function selectedKeyframeMarkers(): { offset: number; easing?: string }[] {
+  function selectedKeyframeMarkers(): { offset: number; easing?: string; properties: string[] }[] {
     const node = selectedAnimationAst();
     if (node?.keyframes?.length)
-      return node.keyframes.map((frame) => ({ offset: frame.offset, easing: frame.easing }));
+      return node.keyframes.map((frame) => ({
+        offset: frame.offset,
+        easing: frame.easing,
+        properties: Object.keys(frame.properties),
+      }));
     if (node) {
       const animated =
         Object.keys(node.from ?? {}).length > 0 || Object.keys(node.to ?? {}).length > 0;
-      if (animated) return [{ offset: 0 }, { offset: 1 }];
+      if (animated) {
+        return [
+          { offset: 0, properties: Object.keys(node.from ?? {}) },
+          { offset: 1, properties: Object.keys(node.to ?? {}) },
+        ];
+      }
     }
     // Preset-driven animation compiled into the scene graph.
     if (selectedAnimation) {
@@ -2286,8 +2382,12 @@
         return selectedAnimation.keyframes.map((frame) => ({
           offset: frame.offset,
           easing: frame.easing,
+          properties: Object.keys(frame.properties),
         }));
-      return [{ offset: 0 }, { offset: 1 }];
+      return [
+        { offset: 0, properties: Object.keys(selectedAnimation.from ?? {}) },
+        { offset: 1, properties: Object.keys(selectedAnimation.to ?? {}) },
+      ];
     }
     return [];
   }
@@ -2298,14 +2398,15 @@
    * timing and easing changes persist. Conversion is intentionally best-effort.
    */
   function materializeSelectedAnimation(): AnimationNode | null {
-    if (!ast || !selectedElement) return null;
+    const target = selectedAnimationTarget();
+    if (!ast || !target) return null;
     const existing = selectedAnimationAst();
     if (existing) return existing;
     const compiled = selectedAnimation;
     if (!compiled) return null;
     const created: AnimationNode = {
       type: 'Animation',
-      target: selectedElement.id,
+      target,
       from: { ...(compiled.from ?? {}) },
       to: { ...(compiled.to ?? {}) },
       keyframes: (compiled.keyframes ?? []).map((frame) => ({
@@ -2319,7 +2420,7 @@
     };
     const elementNode = ast.body.find(
       (candidate): candidate is ElementNode =>
-        candidate.type === 'Element' && candidate.name === selectedElement!.id
+        candidate.type === 'Element' && candidate.name === target
     );
     if (elementNode) {
       const props = { ...elementNode.properties };
@@ -2331,9 +2432,109 @@
     return created;
   }
 
+  function createSelectedAnimation(): AnimationNode | null {
+    const target = selectedAnimationTarget();
+    if (!ast || !target) return null;
+    const created: AnimationNode = {
+      type: 'Animation',
+      target,
+      from: {},
+      to: {},
+      keyframes: [],
+      delay: selectedClip?.start ?? 0,
+      duration: selectedClip?.duration ?? totalDuration,
+      easing: 'power3.out',
+    };
+    ast.body.push(created);
+    return created;
+  }
+
+  function selectedAnimationTiming(node: AnimationNode): { delay: number; duration: number } {
+    if (selectedAnimation?.target === node.target) {
+      return { delay: selectedAnimation.delay, duration: selectedAnimation.duration };
+    }
+    const delay = Number.parseFloat(String(node.delay ?? 0));
+    const duration = Number.parseFloat(String(node.duration ?? totalDuration));
+    return {
+      delay: Number.isFinite(delay) ? delay : 0,
+      duration: Number.isFinite(duration) && duration > 0 ? duration : totalDuration,
+    };
+  }
+
+  function selectedAnimationOffset(node: AnimationNode): number {
+    const timing = selectedAnimationTiming(node);
+    return keyframeOffsetAtTime(currentTime, timing.delay, timing.duration);
+  }
+
+  function selectedKeyframeTolerance(node: AnimationNode): number {
+    const { duration } = selectedAnimationTiming(node);
+    return 0.5 / Math.max(1, duration * (scene?.canvas.fps ?? 60));
+  }
+
   /** Convert a from/to animation into explicit keyframes so edits persist. */
   function ensureSeededKeyframes(node: AnimationNode): void {
-    if (!node.keyframes?.length) node.keyframes = seedKeyframes(node.keyframes, node.from, node.to);
+    if (
+      !node.keyframes?.length &&
+      (Object.keys(node.from ?? {}).length || Object.keys(node.to ?? {}).length)
+    ) {
+      node.keyframes = seedKeyframes(node.keyframes, node.from, node.to);
+      node.from = {};
+      node.to = {};
+    }
+  }
+
+  function removeEmptyAnimation(node: AnimationNode) {
+    if (
+      ast &&
+      !node.keyframes?.length &&
+      !Object.keys(node.from ?? {}).length &&
+      !Object.keys(node.to ?? {}).length
+    ) {
+      ast.body = ast.body.filter((candidate) => candidate !== node);
+    }
+  }
+
+  function selectedAnimatedProperties(): string[] {
+    const node = selectedAnimationAst();
+    if (node) {
+      return [...new Set([
+        ...animatedProperties(node.keyframes),
+        ...Object.keys(node.from ?? {}),
+        ...Object.keys(node.to ?? {}),
+      ])];
+    }
+    if (!selectedAnimation) return [];
+    return [...new Set([
+      ...animatedProperties(selectedAnimation.keyframes),
+      ...Object.keys(selectedAnimation.from ?? {}),
+      ...Object.keys(selectedAnimation.to ?? {}),
+    ])];
+  }
+
+  function isPropertyAnimated(properties: string[]): boolean {
+    const animated = new Set(selectedAnimatedProperties());
+    return properties.some((property) => animated.has(property));
+  }
+
+  function hasPropertyKeyframeAtPlayhead(properties: string[]): boolean {
+    const node = selectedAnimationAst();
+    if (!node) return false;
+    const offset = selectedAnimationOffset(node);
+    if (hasKeyframeProperties(node.keyframes, offset, properties, selectedKeyframeTolerance(node))) {
+      return true;
+    }
+    if (Math.abs(offset) < 1e-6) return properties.every((property) => property in (node.from ?? {}));
+    if (Math.abs(offset - 1) < 1e-6) return properties.every((property) => property in (node.to ?? {}));
+    return false;
+  }
+
+  function showKeyframeNotice(message: string) {
+    if (keyframeNoticeTimer) clearTimeout(keyframeNoticeTimer);
+    keyframeNotice = message;
+    keyframeNoticeTimer = setTimeout(() => {
+      keyframeNotice = '';
+      keyframeNoticeTimer = null;
+    }, 1600);
   }
 
   function keyframeEasingAt(offset: number | null): string {
@@ -2355,120 +2556,177 @@
   function deleteKeyframeAt(event: Event, offset: number) {
     event.preventDefault();
     event.stopPropagation();
-    const node = selectedAnimationAst();
-    if (!ast || !node?.keyframes?.length) return;
+    const node = materializeSelectedAnimation();
+    if (!ast || !node) return;
+    ensureSeededKeyframes(node);
+    if (!node.keyframes?.length) return;
     node.keyframes = removeKeyframe(node.keyframes, offset);
+    removeEmptyAnimation(node);
     if (selectedKeyframeOffset !== null && Math.abs(selectedKeyframeOffset - offset) < 1e-6)
       selectedKeyframeOffset = null;
     code = serializeProgram(ast);
+    showKeyframeNotice('Keyframe deleted');
   }
 
   $: selectedKeyframeEasingValue =
     code && selectedKeyframeOffset !== null ? keyframeEasingAt(selectedKeyframeOffset) : '';
 
   function keyframeTime(offset: number): number {
-    return (selectedAnimation?.delay ?? 0) + offset * (selectedAnimation?.duration ?? 1);
+    const node = selectedAnimationAst();
+    const timing = node
+      ? selectedAnimationTiming(node)
+      : { delay: selectedAnimation?.delay ?? 0, duration: selectedAnimation?.duration ?? 1 };
+    return timing.delay + offset * timing.duration;
   }
 
   function capturedKeyframeProperties(keys?: string[]): Record<string, unknown> {
-    const evaluated = currentFrame?.elements.find((element) => element.id === selectedElement?.id);
-    const source = evaluated ? propertiesOf(evaluated) : selectedElement ? propertiesOf(selectedElement) : {};
-    const defaults = ['x', 'y', 'scale', 'rotation', 'opacity', 'blur'];
-    const names = keys?.length ? keys : defaults;
+    const source = selectedEvaluatedElement() ? propertiesOf(selectedEvaluatedElement()!) : {};
+    const element = ast?.body.find(
+      (node): node is ElementNode =>
+        node.type === 'Element' && node.name === selectedAnimationTarget()
+    );
+    const names = keys?.length
+      ? keys
+      : [
+          ...new Set([
+            ...DEFAULT_KEYFRAME_PROPERTIES,
+            ...Object.keys(element?.properties ?? {}),
+            ...selectedAnimatedProperties(),
+          ]),
+        ];
     return Object.fromEntries(
       names
-        .filter((key) => typeof source[key] === 'number' || typeof source[key] === 'string')
+        .filter((key) => {
+          const value = source[key];
+          return (
+            !TIMING_PROPERTIES.has(key) &&
+            (typeof value === 'number' ||
+              (typeof value === 'string' && (value.startsWith('#') || value.startsWith('rgb'))))
+          );
+        })
         .map((key) => [key, source[key]])
     );
   }
 
   function addKeyframeAtPlayhead() {
-    if (!ast || !selectedElement) return;
-    let node = materializeSelectedAnimation();
-    if (!node) {
-      const base = capturedKeyframeProperties();
-      node = {
-        type: 'Animation',
-        target: selectedElement.id,
-        from: {},
-        to: {},
-        keyframes: [
-          { offset: 0, properties: { ...base } },
-          { offset: 1, properties: { ...base } },
-        ],
-        delay: 0,
-        duration: totalDuration,
-        easing: 'power3.out',
-      };
-      ast.body.push(node);
-    } else {
-      node.keyframes = seedKeyframes(node.keyframes, node.from, node.to);
-    }
-    const delay = selectedAnimation?.delay ?? Number(node.delay ?? 0);
-    const duration = selectedAnimation?.duration ?? (Number(node.duration ?? totalDuration) || totalDuration);
-    const offset = Math.min(1, Math.max(0, (currentTime - delay) / Math.max(duration, 1e-6)));
-    const propertyKeys = Array.from(
-      new Set((node.keyframes ?? []).flatMap((frame) => Object.keys(frame.properties)))
-    );
+    if (!ast || !selectedAnimationTarget()) return;
+    const node = materializeSelectedAnimation() ?? createSelectedAnimation();
+    if (!node) return;
+    ensureSeededKeyframes(node);
+    const offset = selectedAnimationOffset(node);
     node.keyframes = upsertKeyframe(
       node.keyframes ?? [],
       offset,
-      capturedKeyframeProperties(propertyKeys)
+      capturedKeyframeProperties(),
+      selectedKeyframeTolerance(node)
     );
     node.from = {};
     node.to = {};
     selectedKeyframeOffset = offset;
     code = serializeProgram(ast);
+    showKeyframeNotice('Keyframe created');
+  }
+
+  function togglePropertyKeyframe(properties: string[]) {
+    if (!ast || !selectedAnimationTarget()) return;
+    const node = materializeSelectedAnimation() ?? createSelectedAnimation();
+    if (!node) return;
+    ensureSeededKeyframes(node);
+    const offset = selectedAnimationOffset(node);
+    const tolerance = selectedKeyframeTolerance(node);
+    if (hasKeyframeProperties(node.keyframes, offset, properties, tolerance)) {
+      node.keyframes = removeKeyframeProperties(node.keyframes ?? [], offset, properties, tolerance);
+      removeEmptyAnimation(node);
+      selectedKeyframeOffset = null;
+      showKeyframeNotice(`${properties.join('/')} keyframe deleted`);
+    } else {
+      node.keyframes = upsertKeyframe(
+        node.keyframes ?? [],
+        offset,
+        capturedKeyframeProperties(properties),
+        tolerance
+      );
+      selectedKeyframeOffset = offset;
+      showKeyframeNotice(`${properties.join('/')} keyframe created`);
+    }
+    node.from = {};
+    node.to = {};
+    removeEmptyAnimation(node);
+    code = serializeProgram(ast);
   }
 
   function deleteSelectedKeyframe() {
-    const node = selectedAnimationAst();
+    const node = materializeSelectedAnimation();
     if (!node || selectedKeyframeOffset === null) return;
+    ensureSeededKeyframes(node);
     node.keyframes = removeKeyframe(node.keyframes ?? [], selectedKeyframeOffset);
+    removeEmptyAnimation(node);
     selectedKeyframeOffset = null;
     code = serializeProgram(ast!);
+    showKeyframeNotice('Keyframe deleted');
   }
 
   function dragKeyframeMarker(event: PointerEvent, offset: number) {
-    if (event.button !== 0 || !selectedAnimation) return;
+    if (event.button !== 0 || !selectedAnimationTarget()) return;
     event.preventDefault();
     event.stopPropagation();
     const lane = (event.currentTarget as HTMLElement).closest<HTMLElement>('.me-track-lane');
     if (!lane) return;
-    // Materialize preset/from-to animations into real keyframes before editing.
-    const seedNode = materializeSelectedAnimation();
-    if (seedNode && !seedNode.keyframes?.length) {
-      ensureSeededKeyframes(seedNode);
-    }
-    code = serializeProgram(ast!);
     const rect = lane.getBoundingClientRect();
-    const animationDelay = selectedAnimation.delay;
-    const animationDuration = selectedAnimation.duration;
-    let previousOffset = offset;
-    selectedKeyframeOffset = offset;
-    setTime(keyframeTime(offset));
+    const startX = event.clientX;
+    let node: AnimationNode | null = null;
+    let frame: NonNullable<AnimationNode['keyframes']>[number] | null = null;
+    let moved = false;
+    selectKeyframeMarker(offset);
     const move = (pointer: PointerEvent) => {
+      if (!moved && Math.abs(pointer.clientX - startX) < 3) return;
+      if (!moved) {
+        node = materializeSelectedAnimation();
+        if (!node) return;
+        ensureSeededKeyframes(node);
+        frame = node.keyframes?.reduce<typeof frame>(
+          (closest, candidate) =>
+            !closest || Math.abs(candidate.offset - offset) < Math.abs(closest.offset - offset)
+              ? candidate
+              : closest,
+          null
+        ) ?? null;
+        if (!frame) return;
+        moved = true;
+        document.body.style.userSelect = 'none';
+        document.body.style.cursor = 'ew-resize';
+      }
+      if (!node || !frame) return;
+      const timing = selectedAnimationTiming(node);
       const raw = ((pointer.clientX - rect.left) / rect.width) * totalDuration;
       const snappedTime = snapTimelineTime(raw, rect.width);
-      const nextOffset = Math.min(
-        1,
-        Math.max(0, (snappedTime - animationDelay) / Math.max(animationDuration, 1e-6))
-      );
-      const node = selectedAnimationAst();
-      if (!node) return;
-      node.keyframes = moveKeyframe(node.keyframes ?? [], previousOffset, nextOffset);
-      previousOffset = nextOffset;
+      const nextOffset = keyframeOffsetAtTime(snappedTime, timing.delay, timing.duration);
+      frame.offset = nextOffset;
+      node.keyframes = [...(node.keyframes ?? [])].sort((left, right) => left.offset - right.offset);
       selectedKeyframeOffset = nextOffset;
-      code = serializeProgram(ast!);
+      currentTime = quantizeTimelineTime(timing.delay + nextOffset * timing.duration);
     };
     const stop = () => {
       window.removeEventListener('pointermove', move);
       window.removeEventListener('pointerup', stop);
       window.removeEventListener('pointercancel', stop);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      timelineSnapGuide = null;
+      if (moved && node && ast) {
+        node.keyframes = mergeCoincidentKeyframes(node.keyframes ?? []);
+        code = serializeProgram(ast);
+        showKeyframeNotice('Keyframe moved');
+      }
     };
     window.addEventListener('pointermove', move);
     window.addEventListener('pointerup', stop);
     window.addEventListener('pointercancel', stop);
+  }
+
+  function selectKeyframeMarker(offset: number) {
+    selectedKeyframeOffset = offset;
+    setTime(keyframeTime(offset));
   }
 
   function updateAnimationProperty(key: keyof AnimationNode, value: string | number) {
@@ -2580,6 +2838,8 @@
     node.keyframes = moveKeyframe(node.keyframes ?? [], selectedKeyframeOffset, next);
     selectedKeyframeOffset = next;
     code = serializeProgram(ast);
+    setTime(keyframeTime(next));
+    showKeyframeNotice('Keyframe moved');
   }
 
   function toggleTimelineSnap() {
@@ -2691,7 +2951,12 @@
       onRemoveTransition={removeSelectedTransition}
       onAlignSelected={alignSelected}
       {selectedVisualProperty}
+      {selectedVisualStringProperty}
+      {animatedPropertyNames}
+      {isPropertyAnimated}
+      {hasPropertyKeyframeAtPlayhead}
       onUpdateElementProperty={updateElementProperty}
+      onTogglePropertyKeyframe={togglePropertyKeyframe}
       onBeginPropertyScrub={beginPropertyScrub}
       onPropertyScrubKey={handlePropertyScrubKey}
       {timelineRange}
@@ -2772,7 +3037,7 @@
     onSeek={seek}
     {timelineTrackDisplayOrder}
     onUpdateTrack={updateTrack}
-    {selectedKeyframeMarkers}
+    selectedKeyframeMarkers={selectedKeyframeMarkerList}
     {keyframeTime}
     onMoveTimelineElement={moveTimelineElement}
     onSelectElement={selectElement}
@@ -2781,6 +3046,7 @@
     onDeleteElement={deleteElement}
     onTrimElement={trimElement}
     onDragKeyframe={dragKeyframeMarker}
+    onSelectKeyframe={selectKeyframeMarker}
     onDeleteKeyframeAt={deleteKeyframeAt}
     onAddKeyframe={addKeyframeAtPlayhead}
     onMoveTimelineAudio={moveTimelineAudio}
@@ -2798,6 +3064,7 @@
 
 <EditorFeedback
   {deleteToast}
+  {keyframeNotice}
   {showConfirmDialog}
   onUndoDelete={undoDelete}
   onCancelPreset={cancelLoadPreset}

--- a/src/ui/components/motion-editor/EditorFeedback.svelte
+++ b/src/ui/components/motion-editor/EditorFeedback.svelte
@@ -3,6 +3,7 @@
   import { X } from 'lucide-svelte';
 
   export let deleteToast: string;
+  export let keyframeNotice: string;
   export let showConfirmDialog: boolean;
   export let onUndoDelete: () => void;
   export let onCancelPreset: () => void;
@@ -15,6 +16,10 @@
     <span class="me-toast-separator" aria-hidden="true">·</span>
     <button type="button" on:click={onUndoDelete}>Undo</button>
   </div>
+{/if}
+
+{#if keyframeNotice}
+  <div class="me-keyframe-toast" role="status" aria-live="polite">{keyframeNotice}</div>
 {/if}
 
 {#if showConfirmDialog}

--- a/src/ui/components/motion-editor/PropertiesInspector.svelte
+++ b/src/ui/components/motion-editor/PropertiesInspector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './properties-inspector.css';
-  import { AlignHorizontalJustifyCenter, AlignHorizontalJustifyEnd, AlignHorizontalJustifyStart, AlignVerticalJustifyCenter, AlignVerticalJustifyEnd, AlignVerticalJustifyStart, FileImage, Sparkles, Square, Trash2, Type, Video, Wand2 } from 'lucide-svelte';
+  import { AlignHorizontalJustifyCenter, AlignHorizontalJustifyEnd, AlignHorizontalJustifyStart, AlignVerticalJustifyCenter, AlignVerticalJustifyEnd, AlignVerticalJustifyStart, Diamond, FileImage, Sparkles, Square, Trash2, Type, Video, Wand2 } from 'lucide-svelte';
   import type { LoadedAsset } from '../../../assets/asset-loader';
   import type { AnimationNode } from '../../../types/parser';
   import type { Animation, Clip, Element, Scene } from '../../../types/scene';
@@ -27,8 +27,13 @@
   export let onApplyTransition: (boundary: ClipTransitionBoundary, duration: number) => void;
   export let onRemoveTransition: () => void;
   export let onAlignSelected: (alignment: Alignment) => void;
-  export let selectedVisualProperty: (key: string, fallback: number) => number;
+  export let selectedVisualProperty: (key: string, fallback: number, time?: number) => number;
+  export let selectedVisualStringProperty: (key: string, fallback: string) => string;
+  export let animatedPropertyNames: string[];
+  export let isPropertyAnimated: (properties: string[]) => boolean;
+  export let hasPropertyKeyframeAtPlayhead: (properties: string[]) => boolean;
   export let onUpdateElementProperty: (key: string, value: string | number | boolean) => void;
+  export let onTogglePropertyKeyframe: (properties: string[]) => void;
   export let onBeginPropertyScrub: (event: PointerEvent, key: string, fallback: number, minimum?: number) => void;
   export let onPropertyScrubKey: (event: KeyboardEvent, key: string, fallback: number, minimum?: number) => void;
   export let timelineRange: (id: string) => { start: number; end: number };
@@ -106,7 +111,10 @@
           </div>
           {/if}
           <div class="me-property-group">
-            <div class="me-property-label">Position</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Position</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['x', 'y'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['x', 'y'])} on:click={() => onTogglePropertyKeyframe(['x', 'y'])} title="Toggle position keyframe at playhead" aria-label="Toggle position keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['x', 'y'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <div class="me-property-row">
               <div class="me-number-input-wrapper">
                 <input class="me-number-input" type="number" value={selectedVisualProperty('x', 0)} on:input={(event) => onUpdateElementProperty('x', Number(event.currentTarget.value))} />
@@ -119,7 +127,10 @@
             </div>
           </div>
           <div class="me-property-group me-rotation-property">
-            <div class="me-property-label">Rotation</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Rotation</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['rotation'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['rotation'])} on:click={() => onTogglePropertyKeyframe(['rotation'])} title="Toggle rotation keyframe at playhead" aria-label="Toggle rotation keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['rotation'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <RotationDial value={selectedVisualProperty('rotation', 0)} onChange={(angle) => onUpdateElementProperty('rotation', angle)} />
           </div>
           {#if selectedElement.kind === 'text'}
@@ -128,38 +139,54 @@
               <textarea class="me-text-input" rows="3" value={stringProperty(selectedElement, 'value', '')} on:input={(event) => onUpdateElementProperty('value', event.currentTarget.value)}></textarea>
             </div>
             <div class="me-property-group">
-              <div class="me-property-label">Font Size</div>
+              <div class="me-property-label-row">
+                <div class="me-property-label">Font Size</div>
+                <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['size'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['size'])} on:click={() => onTogglePropertyKeyframe(['size'])} title="Toggle font size keyframe at playhead" aria-label="Toggle font size keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['size'])}><Diamond size={11} fill="currentColor" /></button>
+              </div>
               <div class="me-number-input-wrapper">
-                <input class="me-number-input" type="number" min="1" value={numericProperty(selectedElement, 'size', 72)} on:input={(event) => onUpdateElementProperty('size', Number(event.currentTarget.value))} />
+                <input class="me-number-input" type="number" min="1" value={selectedVisualProperty('size', 72)} on:input={(event) => onUpdateElementProperty('size', Number(event.currentTarget.value))} />
                 <button type="button" class="me-input-suffix me-scrubbable-suffix" on:pointerdown={(event) => onBeginPropertyScrub(event, 'size', 72, 1)} on:keydown={(event) => onPropertyScrubKey(event, 'size', 72, 1)} aria-label="Font size: drag up or down to adjust" title="Drag up or down to adjust font size">px</button>
               </div>
             </div>
           {/if}
           <div class="me-property-group">
-            <div class="me-property-label">Scale</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Scale</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['scale'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['scale'])} on:click={() => onTogglePropertyKeyframe(['scale'])} title="Toggle scale keyframe at playhead" aria-label="Toggle scale keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['scale'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <div class="me-slider-control">
-              <input class="me-custom-slider" type="range" min="0" max="3" step="0.01" value={numericProperty(selectedElement, 'scale', 1)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale" />
-              <input class="me-slider-value-input" type="number" min="0" step="0.01" value={numericProperty(selectedElement, 'scale', 1).toFixed(2)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale value" />
+              <input class="me-custom-slider" type="range" min="0" max="3" step="0.01" value={selectedVisualProperty('scale', 1, currentTime)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale" />
+              <input class="me-slider-value-input" type="number" min="0" step="0.01" value={selectedVisualProperty('scale', 1, currentTime).toFixed(2)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale value" />
             </div>
           </div>
           <div class="me-property-group">
-            <div class="me-property-label">Opacity</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Opacity</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['opacity'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['opacity'])} on:click={() => onTogglePropertyKeyframe(['opacity'])} title="Toggle opacity keyframe at playhead" aria-label="Toggle opacity keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['opacity'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <div class="me-slider-control">
-              <input class="me-custom-slider" type="range" min="0" max="1" step="0.01" value={numericProperty(selectedElement, 'opacity', 1)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value))} aria-label="Opacity" />
-              <input class="me-slider-value-input" type="number" min="0" max="100" value={Math.round(numericProperty(selectedElement, 'opacity', 1) * 100)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value) / 100)} aria-label="Opacity percentage" />
+              <input class="me-custom-slider" type="range" min="0" max="1" step="0.01" value={selectedVisualProperty('opacity', 1)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value))} aria-label="Opacity" />
+              <input class="me-slider-value-input" type="number" min="0" max="100" value={Math.round(selectedVisualProperty('opacity', 1) * 100)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value) / 100)} aria-label="Opacity percentage" />
             </div>
           </div>
           <div class="me-property-group">
-            <div class="me-property-label">Color</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Color</div>
+              {#if selectedElement.kind === 'text'}
+                <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['color'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['color'])} on:click={() => onTogglePropertyKeyframe(['color'])} title="Toggle color keyframe at playhead" aria-label="Toggle color keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['color'])}><Diamond size={11} fill="currentColor" /></button>
+              {:else if selectedElement.kind === 'overlay' || selectedElement.asset?.type === 'svg'}
+                <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['fill'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['fill'])} on:click={() => onTogglePropertyKeyframe(['fill'])} title="Toggle color keyframe at playhead" aria-label="Toggle color keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['fill'])}><Diamond size={11} fill="currentColor" /></button>
+              {/if}
+            </div>
             {#if selectedElement.kind === 'text'}
               <ColorPicker
-                value={stringProperty(selectedElement, 'color', '#ffffff')}
+                value={selectedVisualStringProperty('color', '#ffffff')}
                 ariaLabel="Text color"
                 onChange={(color) => onUpdateElementProperty('color', color)}
               />
             {:else if selectedElement.kind === 'overlay' || selectedElement.asset?.type === 'svg'}
               <ColorPicker
-                value={stringProperty(selectedElement, 'fill', '#ffffff')}
+                value={selectedVisualStringProperty('fill', '#ffffff')}
                 ariaLabel="Layer color"
                 onChange={(color) => onUpdateElementProperty('fill', color)}
               />
@@ -271,7 +298,10 @@
           <div class="me-section-title">Adjustments</div>
           {#each ADJUSTMENT_CONTROLS as control}
             <div class="me-property-group">
-              <div class="me-property-label">{control.label}</div>
+              <div class="me-property-label-row">
+                <div class="me-property-label">{control.label}</div>
+                <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated([control.property])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead([control.property])} on:click={() => onTogglePropertyKeyframe([control.property])} title={`Toggle ${control.label.toLowerCase()} keyframe at playhead`} aria-label={`Toggle ${control.label.toLowerCase()} keyframe at playhead`} aria-pressed={hasPropertyKeyframeAtPlayhead([control.property])}><Diamond size={11} fill="currentColor" /></button>
+              </div>
               <div class="me-slider-control">
                 <input
                   class="me-custom-slider"
@@ -279,7 +309,7 @@
                   min={control.min}
                   max={control.max}
                   step={control.step}
-                  value={numericProperty(selectedElement, control.property, control.fallback)}
+                  value={selectedVisualProperty(control.property, control.fallback)}
                   on:input={(event) => onUpdateElementProperty(control.property, Number(event.currentTarget.value))}
                 />
                 <input
@@ -288,7 +318,7 @@
                   min={control.min}
                   max={control.max}
                   step={control.step}
-                  value={numericProperty(selectedElement, control.property, control.fallback)}
+                  value={selectedVisualProperty(control.property, control.fallback)}
                   on:input={(event) => onUpdateElementProperty(control.property, Number(event.currentTarget.value))}
                 />
               </div>
@@ -297,8 +327,15 @@
         {/if}
 
         <div class="me-section-title">Keyframes</div>
+        {#if animatedPropertyNames.length}
+          <div class="me-animated-properties" aria-label="Animated properties">
+            {#each animatedPropertyNames as property}
+              <span>{property}</span>
+            {/each}
+          </div>
+        {/if}
         <div class="me-property-group me-keyframe-controls">
-          <button type="button" class="me-timeline-command" on:click={onAddKeyframe}>◆ Add at playhead</button>
+          <button type="button" class="me-timeline-command" on:click={onAddKeyframe}><Diamond size={12} fill="currentColor" /> Add at playhead</button>
           {#if selectedKeyframeOffset !== null}
             <div class="me-number-input-wrapper">
               <input
@@ -450,7 +487,10 @@
             </div>
           </div>
           <div class="me-property-group">
-            <div class="me-property-label">Position</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Position</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['x', 'y'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['x', 'y'])} on:click={() => onTogglePropertyKeyframe(['x', 'y'])} title="Toggle position keyframe at playhead" aria-label="Toggle position keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['x', 'y'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <div class="me-property-row">
               <div class="me-number-input-wrapper">
                 <input class="me-number-input" type="number" value={selectedVisualProperty('x', 0)} on:input={(event) => onUpdateElementProperty('x', Number(event.currentTarget.value))} />
@@ -463,29 +503,43 @@
             </div>
           </div>
           <div class="me-property-group me-rotation-property">
-            <div class="me-property-label">Rotation</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Rotation</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['rotation'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['rotation'])} on:click={() => onTogglePropertyKeyframe(['rotation'])} title="Toggle rotation keyframe at playhead" aria-label="Toggle rotation keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['rotation'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <RotationDial value={selectedVisualProperty('rotation', 0)} onChange={(angle) => onUpdateElementProperty('rotation', angle)} />
           </div>
           <p class="me-shared-property-note">Visual changes apply to every clip using this source asset.</p>
           <div class="me-property-group">
-            <div class="me-property-label">Scale</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Scale</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['scale'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['scale'])} on:click={() => onTogglePropertyKeyframe(['scale'])} title="Toggle scale keyframe at playhead" aria-label="Toggle scale keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['scale'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <div class="me-slider-control">
-              <input class="me-custom-slider" type="range" min="0.05" max="3" step="0.01" value={numericProperty(selectedClipElement, 'scale', 1)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale" />
-              <input class="me-slider-value-input" type="number" min="0.05" step="0.01" value={numericProperty(selectedClipElement, 'scale', 1).toFixed(2)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale value" />
+              <input class="me-custom-slider" type="range" min="0.05" max="3" step="0.01" value={selectedVisualProperty('scale', 1, currentTime)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale" />
+              <input class="me-slider-value-input" type="number" min="0.05" step="0.01" value={selectedVisualProperty('scale', 1, currentTime).toFixed(2)} on:input={(event) => onUpdateElementProperty('scale', Number(event.currentTarget.value))} aria-label="Scale value" />
             </div>
           </div>
           <div class="me-property-group">
-            <div class="me-property-label">Opacity</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Opacity</div>
+              <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['opacity'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['opacity'])} on:click={() => onTogglePropertyKeyframe(['opacity'])} title="Toggle opacity keyframe at playhead" aria-label="Toggle opacity keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['opacity'])}><Diamond size={11} fill="currentColor" /></button>
+            </div>
             <div class="me-slider-control">
-              <input class="me-custom-slider" type="range" min="0" max="1" step="0.01" value={numericProperty(selectedClipElement, 'opacity', 1)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value))} aria-label="Opacity" />
-              <input class="me-slider-value-input" type="number" min="0" max="100" value={Math.round(numericProperty(selectedClipElement, 'opacity', 1) * 100)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value) / 100)} aria-label="Opacity percentage" />
+              <input class="me-custom-slider" type="range" min="0" max="1" step="0.01" value={selectedVisualProperty('opacity', 1)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value))} aria-label="Opacity" />
+              <input class="me-slider-value-input" type="number" min="0" max="100" value={Math.round(selectedVisualProperty('opacity', 1) * 100)} on:input={(event) => onUpdateElementProperty('opacity', Number(event.currentTarget.value) / 100)} aria-label="Opacity percentage" />
             </div>
           </div>
           <div class="me-property-group">
-            <div class="me-property-label">Color</div>
+            <div class="me-property-label-row">
+              <div class="me-property-label">Color</div>
+              {#if selectedClipElement?.asset?.type === 'svg'}
+                <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['fill'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['fill'])} on:click={() => onTogglePropertyKeyframe(['fill'])} title="Toggle color keyframe at playhead" aria-label="Toggle color keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['fill'])}><Diamond size={11} fill="currentColor" /></button>
+              {/if}
+            </div>
             {#if selectedClipElement?.asset?.type === 'svg'}
               <ColorPicker
-                value={stringProperty(selectedClipElement, 'fill', '#ffffff')}
+                value={selectedVisualStringProperty('fill', '#ffffff')}
                 ariaLabel="Clip color"
                 onChange={(color) => onUpdateElementProperty('fill', color)}
               />
@@ -509,6 +563,20 @@
               </div>
             </div>
           </div>
+        </div>
+        <div class="me-section-title">Keyframes</div>
+        {#if animatedPropertyNames.length}
+          <div class="me-animated-properties" aria-label="Animated properties">
+            {#each animatedPropertyNames as property}
+              <span>{property}</span>
+            {/each}
+          </div>
+        {/if}
+        <div class="me-property-group me-keyframe-controls">
+          <button type="button" class="me-timeline-command" on:click={onAddKeyframe}><Diamond size={12} fill="currentColor" /> Add at playhead</button>
+          {#if selectedKeyframeOffset !== null}
+            <button type="button" class="me-icon-btn me-danger-btn" on:click={onDeleteKeyframe} title="Delete selected keyframe"><Trash2 size={14} /></button>
+          {/if}
         </div>
         <details class="me-more-options" bind:open={moreOptionsOpen}>
           <summary>More Options</summary>

--- a/src/ui/components/motion-editor/TimelinePanel.svelte
+++ b/src/ui/components/motion-editor/TimelinePanel.svelte
@@ -67,7 +67,7 @@
   export let onSeek: (event: Event) => void;
   export let timelineTrackDisplayOrder: (track: Track | null | undefined, fallbackId: string) => number;
   export let onUpdateTrack: (track: Track, updates: { hidden?: boolean; muted?: boolean }) => void;
-  export let selectedKeyframeMarkers: () => { offset: number; easing?: string }[];
+  export let selectedKeyframeMarkers: { offset: number; easing?: string; properties: string[] }[];
   export let keyframeTime: (offset: number) => number;
   export let onMoveTimelineElement: (event: PointerEvent, element: Element) => void;
   export let onSelectElement: (id: string, seek?: boolean) => void;
@@ -76,6 +76,7 @@
   export let onDeleteElement: (id: string) => void;
   export let onTrimElement: (event: PointerEvent, id: string, edge: 'start' | 'end') => void;
   export let onDragKeyframe: (event: PointerEvent, offset: number) => void;
+  export let onSelectKeyframe: (offset: number) => void;
   export let onDeleteKeyframeAt: (event: Event, offset: number) => void;
   export let onAddKeyframe: () => void;
   export let onMoveTimelineAudio: (event: PointerEvent) => void;
@@ -86,6 +87,13 @@
   export let onDropTransition: (event: DragEvent, boundary: ClipTransitionBoundary) => void;
   export let onSelectTransition: (boundary: ClipTransitionBoundary) => void;
   export let onAudioMetadata: (duration: number) => void;
+
+  let keyframeAtPlayhead = false;
+  $: keyframeAtPlayhead = selectedKeyframeMarkers.some(
+    (frame) =>
+      Math.abs(keyframeTime(frame.offset) - currentTime) <=
+      0.5 / (scene?.canvas.fps ?? 60)
+  );
 </script>
 
   <section class="me-timeline-panel">
@@ -198,7 +206,7 @@
             {#if clipDrag && clipDrag.ghostTrackId === row.trackId}
               <span class="me-clip-ghost" class:me-invalid={!clipDrag.valid} style={`left: ${timelinePercent(clipDrag.ghostStart)}%; width: ${Math.max(0.8, timelinePercent(clipDrag.duration))}%`}></span>
               {#if clipDrag.kind === 'element' && clipDrag.id === selectedElementId && !row.items.some((item) => item.element.id === selectedElementId)}
-                {#each selectedKeyframeMarkers() as frame}
+                {#each selectedKeyframeMarkers as frame}
                   <span class="me-keyframe-marker me-drag-keyframe" style={`left: ${timelinePercent(keyframeTime(frame.offset) + keyframeDragDelta)}%; top: 19.5px`} aria-hidden="true"></span>
                 {/each}
               {/if}
@@ -227,27 +235,30 @@
             {/each}
             {#if row.items.some((item) => item.element.id === selectedElementId) && !(clipDrag?.kind === 'element' && clipDrag.id === selectedElementId && clipDrag.ghostTrackId !== row.trackId)}
               {@const kfLane = row.items.find((item) => item.element.id === selectedElementId)?.lane ?? 0}
-              {#each selectedKeyframeMarkers() as frame}
+              {#each selectedKeyframeMarkers as frame}
                 <button
                   type="button"
                   class="me-keyframe-marker"
                   class:me-selected-keyframe={selectedKeyframeOffset !== null && Math.abs(selectedKeyframeOffset - frame.offset) < 0.000001}
                   style={`left: ${timelinePercent(keyframeTime(frame.offset) + keyframeDragDelta)}%; top: ${6 + kfLane * 34 + 13.5}px`}
-                  title={`Keyframe ${Math.round(frame.offset * 100)}%${frame.easing ? ' · ' + frame.easing : ''} — drag to retime, right-click to delete`}
+                  title={`${frame.properties.join(', ') || 'Keyframe'} · ${Math.round(frame.offset * 100)}%${frame.easing ? ' · ' + frame.easing : ''} — drag to retime, right-click to delete`}
                   aria-label={`Keyframe at ${Math.round(frame.offset * 100)} percent`}
                   on:pointerdown={(event) => onDragKeyframe(event, frame.offset)}
+                  on:click|stopPropagation={() => onSelectKeyframe(frame.offset)}
                   on:contextmenu={(event) => onDeleteKeyframeAt(event, frame.offset)}
                 ></button>
               {/each}
-              <button
-                type="button"
-                class="me-keyframe-add"
-                style={`left: ${timelinePercent(currentTime)}%; top: ${6 + kfLane * 34 + 13.5}px`}
-                title="Add keyframe at playhead"
-                aria-label="Add keyframe at playhead"
-                on:pointerdown|stopPropagation
-                on:click|stopPropagation={onAddKeyframe}
-              >+</button>
+              {#if !keyframeAtPlayhead}
+                <button
+                  type="button"
+                  class="me-keyframe-add"
+                  style={`left: ${timelinePercent(currentTime)}%; top: ${6 + kfLane * 34 + 13.5}px`}
+                  title="Add keyframe at playhead"
+                  aria-label="Add keyframe at playhead"
+                  on:pointerdown|stopPropagation
+                  on:click|stopPropagation={onAddKeyframe}
+                >+</button>
+              {/if}
             {/if}
           </div>
         </div>
@@ -290,7 +301,7 @@
               {#if clipDrag && clipDrag.ghostTrackId === String(clipTrack.track)}
                 <span class="me-clip-ghost" class:me-invalid={!clipDrag.valid} style={`left: ${timelinePercent(clipDrag.ghostStart)}%; width: ${Math.max(0.8, timelinePercent(clipDrag.duration))}%`}></span>
                 {#if clipDrag.kind === 'element' && clipDrag.id === selectedElementId && !clipTrack.elements.some(({ item }) => item.element.id === selectedElementId)}
-                  {#each selectedKeyframeMarkers() as frame}
+                  {#each selectedKeyframeMarkers as frame}
                     <span class="me-keyframe-marker me-drag-keyframe" style={`left: ${timelinePercent(keyframeTime(frame.offset) + keyframeDragDelta)}%; top: 19.5px`} aria-hidden="true"></span>
                   {/each}
                 {/if}
@@ -332,27 +343,30 @@
               {/each}
               {#if clipTrack.elements.some(({ item }) => item.element.id === selectedElementId) && !(clipDrag?.kind === 'element' && clipDrag.id === selectedElementId && clipDrag.ghostTrackId !== String(clipTrack.track))}
                 {@const kfLane = clipTrack.elements.find(({ item }) => item.element.id === selectedElementId)?.lane ?? 0}
-                {#each selectedKeyframeMarkers() as frame}
+                {#each selectedKeyframeMarkers as frame}
                   <button
                     type="button"
                     class="me-keyframe-marker"
                     class:me-selected-keyframe={selectedKeyframeOffset !== null && Math.abs(selectedKeyframeOffset - frame.offset) < 0.000001}
                     style={`left: ${timelinePercent(keyframeTime(frame.offset) + keyframeDragDelta)}%; top: ${6 + kfLane * 34 + 13.5}px`}
-                    title={`Keyframe ${Math.round(frame.offset * 100)}%${frame.easing ? ' · ' + frame.easing : ''} — drag to retime, right-click to delete`}
+                    title={`${frame.properties.join(', ') || 'Keyframe'} · ${Math.round(frame.offset * 100)}%${frame.easing ? ' · ' + frame.easing : ''} — drag to retime, right-click to delete`}
                     aria-label={`Keyframe at ${Math.round(frame.offset * 100)} percent`}
                     on:pointerdown={(event) => onDragKeyframe(event, frame.offset)}
+                    on:click|stopPropagation={() => onSelectKeyframe(frame.offset)}
                     on:contextmenu={(event) => onDeleteKeyframeAt(event, frame.offset)}
                   ></button>
                 {/each}
-                <button
-                  type="button"
-                  class="me-keyframe-add"
-                  style={`left: ${timelinePercent(currentTime)}%; top: ${6 + kfLane * 34 + 13.5}px`}
-                  title="Add keyframe at playhead"
-                  aria-label="Add keyframe at playhead"
-                  on:pointerdown|stopPropagation
-                  on:click|stopPropagation={onAddKeyframe}
-                >+</button>
+                {#if !keyframeAtPlayhead}
+                  <button
+                    type="button"
+                    class="me-keyframe-add"
+                    style={`left: ${timelinePercent(currentTime)}%; top: ${6 + kfLane * 34 + 13.5}px`}
+                    title="Add keyframe at playhead"
+                    aria-label="Add keyframe at playhead"
+                    on:pointerdown|stopPropagation
+                    on:click|stopPropagation={onAddKeyframe}
+                  >+</button>
+                {/if}
               {/if}
               {#each clipTrack.clips as packedClip}
                 {@const clip = packedClip.clip}
@@ -380,6 +394,34 @@
                   </button>
                 </span>
               {/each}
+              {#if selectedClip && String(selectedClip.track) === String(clipTrack.track)}
+                {@const selectedPackedClip = clipTrack.clips.find(({ clip }) => clip.id === selectedClip?.id)}
+                {@const selectedClipLane = selectedPackedClip?.lane ?? 0}
+                {#each selectedKeyframeMarkers as frame}
+                  <button
+                    type="button"
+                    class="me-keyframe-marker"
+                    class:me-selected-keyframe={selectedKeyframeOffset !== null && Math.abs(selectedKeyframeOffset - frame.offset) < 0.000001}
+                    style={`left: ${timelinePercent(keyframeTime(frame.offset))}%; top: ${6 + selectedClipLane * 34 + 13.5}px`}
+                    title={`${frame.properties.join(', ') || 'Keyframe'} · ${Math.round(frame.offset * 100)}%${frame.easing ? ' · ' + frame.easing : ''} — drag to retime, right-click to delete`}
+                    aria-label={`Keyframe at ${Math.round(frame.offset * 100)} percent`}
+                    on:pointerdown={(event) => onDragKeyframe(event, frame.offset)}
+                    on:click|stopPropagation={() => onSelectKeyframe(frame.offset)}
+                    on:contextmenu={(event) => onDeleteKeyframeAt(event, frame.offset)}
+                  ></button>
+                {/each}
+                {#if !keyframeAtPlayhead}
+                  <button
+                    type="button"
+                    class="me-keyframe-add"
+                    style={`left: ${timelinePercent(currentTime)}%; top: ${6 + selectedClipLane * 34 + 13.5}px`}
+                    title="Add keyframe at playhead"
+                    aria-label="Add keyframe at playhead"
+                    on:pointerdown|stopPropagation
+                    on:click|stopPropagation={onAddKeyframe}
+                  >+</button>
+                {/if}
+              {/if}
               {#each transitionBoundaries.filter((boundary) => String(boundary.outgoing.track) === String(clipTrack.track)) as boundary}
                 <button
                   type="button"
@@ -408,4 +450,3 @@
 
     <audio bind:this={audioElement} on:loadedmetadata={() => onAudioMetadata(audioElement.duration)}></audio>
   </section>
-

--- a/src/ui/components/motion-editor/editor-theme.css
+++ b/src/ui/components/motion-editor/editor-theme.css
@@ -282,7 +282,8 @@
   right: 23px;
 }
 
-.motion-editor-scope .me-delete-toast {
+.motion-editor-scope .me-delete-toast,
+.motion-editor-scope .me-keyframe-toast {
   position: fixed;
   right: 20px;
   bottom: calc(var(--timeline-height, 230px) + 20px);
@@ -300,6 +301,10 @@
   box-shadow: 0 16px 42px rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(18px);
   font-size: 12px;
+}
+.motion-editor-scope .me-keyframe-toast {
+  min-width: 0;
+  border-color: rgba(244, 184, 96, 0.45);
 }
 .motion-editor-scope .me-delete-toast button {
   height: 28px;
@@ -379,7 +384,8 @@
   color: #77777f;
   margin-left: auto;
 }
-.motion-editor-scope .me-delete-toast {
+.motion-editor-scope .me-delete-toast,
+.motion-editor-scope .me-keyframe-toast {
   gap: 8px;
 }
 

--- a/src/ui/components/motion-editor/properties-inspector.css
+++ b/src/ui/components/motion-editor/properties-inspector.css
@@ -144,6 +144,49 @@
   margin-bottom: 0;
 }
 
+.motion-editor-scope .me-property-keyframe {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #555b64;
+  cursor: pointer;
+}
+
+.motion-editor-scope .me-property-keyframe:hover {
+  background: #202329;
+  color: #f4b860;
+}
+
+.motion-editor-scope .me-property-keyframe.me-animated-property {
+  color: #c58c3d;
+}
+
+.motion-editor-scope .me-property-keyframe.me-keyframe-at-playhead {
+  color: #fff1c9;
+  background: #3b2b16;
+}
+
+.motion-editor-scope .me-animated-properties {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: -4px 0 10px;
+}
+
+.motion-editor-scope .me-animated-properties span {
+  padding: 3px 6px;
+  border: 1px solid #4b3920;
+  border-radius: 3px;
+  background: #211b13;
+  color: #e5b967;
+  font-size: 10px;
+}
+
 .motion-editor-scope .me-property-action {
   padding: 0;
   border: 0;

--- a/src/ui/components/motion-editor/timeline-panel.css
+++ b/src/ui/components/motion-editor/timeline-panel.css
@@ -682,8 +682,8 @@
   position: absolute;
   z-index: 5;
   top: 50%;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   padding: 0;
   border: 1px solid #111318;
   border-radius: 1px;
@@ -698,6 +698,15 @@
 .motion-editor-scope .me-keyframe-marker.me-selected-keyframe {
   background: #fff1c9;
   box-shadow: 0 0 0 2px #f4b860;
+}
+
+.motion-editor-scope .me-keyframe-marker:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 3px;
+}
+
+.motion-editor-scope .me-keyframe-marker:active {
+  cursor: grabbing;
 }
 
 .motion-editor-scope .me-drag-keyframe {

--- a/src/ui/keyframe-editing.ts
+++ b/src/ui/keyframe-editing.ts
@@ -5,8 +5,50 @@ function clampOffset(value: number): number {
   return Math.min(1, Math.max(0, value));
 }
 
+function snapshot<T>(value: T): T {
+  return structuredClone(value);
+}
+
 function sorted(frames: KeyframeNode[]): KeyframeNode[] {
   return [...frames].sort((a, b) => a.offset - b.offset);
+}
+
+function logEdit(operation: string, before: KeyframeNode[], after: KeyframeNode[]): void {
+  const debug = globalThis as typeof globalThis & { __MOTIONLY_DEBUG_KEYFRAMES__?: boolean };
+  if (!debug.__MOTIONLY_DEBUG_KEYFRAMES__) return;
+  console.debug(`[Motionly keyframes] ${operation} before`, snapshot(before));
+  console.debug(`[Motionly keyframes] ${operation} after`, snapshot(after));
+}
+
+export function mergeCoincidentKeyframes(frames: KeyframeNode[], tolerance = 1e-6): KeyframeNode[] {
+  return sorted(snapshot(frames)).reduce<KeyframeNode[]>((merged, frame) => {
+    const previous = merged[merged.length - 1];
+    if (previous && Math.abs(previous.offset - frame.offset) <= tolerance) {
+      previous.properties = { ...previous.properties, ...frame.properties };
+      if (frame.easing) previous.easing = frame.easing;
+    } else {
+      merged.push(frame);
+    }
+    return merged;
+  }, []);
+}
+
+export function animatedProperties(frames: KeyframeNode[] | undefined): string[] {
+  return [...new Set((frames ?? []).flatMap((frame) => Object.keys(frame.properties)))];
+}
+
+export function keyframeOffsetAtTime(time: number, delay: number, duration: number): number {
+  return clampOffset((time - delay) / Math.max(duration, 1e-6));
+}
+
+export function hasKeyframeProperties(
+  frames: KeyframeNode[] | undefined,
+  offset: number,
+  properties: string[],
+  tolerance = 1e-6
+): boolean {
+  const frame = frames?.find((candidate) => Math.abs(candidate.offset - offset) <= tolerance);
+  return Boolean(frame && properties.every((property) => property in frame.properties));
 }
 
 export function seedKeyframes(
@@ -14,11 +56,10 @@ export function seedKeyframes(
   from: Record<string, unknown> = {},
   to: Record<string, unknown> = {}
 ): KeyframeNode[] {
-  if (frames?.length)
-    return frames.map((frame) => ({ ...frame, properties: { ...frame.properties } }));
+  if (frames?.length) return snapshot(frames);
   return [
-    { offset: 0, properties: { ...from } },
-    { offset: 1, properties: { ...to } },
+    { offset: 0, properties: snapshot(from) },
+    { offset: 1, properties: snapshot(to) },
   ];
 }
 
@@ -29,17 +70,18 @@ export function upsertKeyframe(
   tolerance = 1e-6
 ): KeyframeNode[] {
   const nextOffset = clampOffset(offset);
-  const existing = frames.find((frame) => Math.abs(frame.offset - nextOffset) <= tolerance);
+  const before = snapshot(frames);
+  const next = snapshot(frames);
+  const existing = next.find((frame) => Math.abs(frame.offset - nextOffset) <= tolerance);
   if (existing) {
-    return sorted(
-      frames.map((frame) =>
-        frame === existing
-          ? { ...frame, offset: nextOffset, properties: { ...frame.properties, ...properties } }
-          : { ...frame, properties: { ...frame.properties } }
-      )
-    );
+    existing.offset = nextOffset;
+    existing.properties = { ...existing.properties, ...snapshot(properties) };
+  } else {
+    next.push({ offset: nextOffset, properties: snapshot(properties) });
   }
-  return sorted([...frames, { offset: nextOffset, properties: { ...properties } }]);
+  const after = sorted(next);
+  logEdit(existing ? 'update' : 'add', before, after);
+  return after;
 }
 
 /** Set the easing that governs the transition into the keyframe at `offset`. */
@@ -49,10 +91,8 @@ export function setKeyframeEasing(
   easing: string,
   tolerance = 1e-6
 ): KeyframeNode[] {
-  return frames.map((frame) =>
-    Math.abs(frame.offset - offset) <= tolerance
-      ? { ...frame, properties: { ...frame.properties }, easing: easing || undefined }
-      : { ...frame, properties: { ...frame.properties } }
+  return snapshot(frames).map((frame) =>
+    Math.abs(frame.offset - offset) <= tolerance ? { ...frame, easing: easing || undefined } : frame
   );
 }
 
@@ -62,14 +102,47 @@ export function moveKeyframe(
   nextOffset: number,
   tolerance = 1e-6
 ): KeyframeNode[] {
-  const index = frames.findIndex((frame) => Math.abs(frame.offset - previousOffset) <= tolerance);
-  if (index < 0) return frames;
-  const moved = frames.map((frame, frameIndex) =>
-    frameIndex === index
-      ? { ...frame, offset: clampOffset(nextOffset), properties: { ...frame.properties } }
-      : { ...frame, properties: { ...frame.properties } }
+  const moved = snapshot(frames);
+  const index = moved.findIndex((frame) => Math.abs(frame.offset - previousOffset) <= tolerance);
+  if (index < 0) return moved;
+  const next = clampOffset(nextOffset);
+  moved[index]!.offset = next;
+  const collision = moved.findIndex(
+    (frame, frameIndex) => frameIndex !== index && Math.abs(frame.offset - next) <= tolerance
   );
+  if (collision >= 0) {
+    const source = moved[index]!;
+    const target = moved[collision]!;
+    const merged = {
+      ...target,
+      properties: { ...target.properties, ...source.properties },
+      ...(source.easing ? { easing: source.easing } : {}),
+    };
+    return sorted(
+      moved
+        .filter((_, frameIndex) => frameIndex !== index)
+        .map((frame, frameIndex) =>
+          frameIndex === (collision > index ? collision - 1 : collision) ? merged : frame
+        )
+    );
+  }
   return sorted(moved);
+}
+
+export function removeKeyframeProperties(
+  frames: KeyframeNode[],
+  offset: number,
+  properties: string[],
+  tolerance = 1e-6
+): KeyframeNode[] {
+  return snapshot(frames).flatMap((frame) => {
+    if (Math.abs(frame.offset - offset) > tolerance) {
+      return [frame];
+    }
+    const remaining = { ...frame.properties };
+    for (const property of properties) delete remaining[property];
+    return Object.keys(remaining).length ? [{ ...frame, properties: remaining }] : [];
+  });
 }
 
 export function removeKeyframe(
@@ -77,7 +150,5 @@ export function removeKeyframe(
   offset: number,
   tolerance = 1e-6
 ): KeyframeNode[] {
-  return frames
-    .filter((frame) => Math.abs(frame.offset - offset) > tolerance)
-    .map((frame) => ({ ...frame, properties: { ...frame.properties } }));
+  return snapshot(frames).filter((frame) => Math.abs(frame.offset - offset) > tolerance);
 }

--- a/src/ui/timeline-model.ts
+++ b/src/ui/timeline-model.ts
@@ -1,11 +1,17 @@
 import type { AnimationNode, KeyframeNode } from '../types/parser';
+import {
+  keyframeOffsetAtTime as offsetAtTime,
+  moveKeyframe as moveFrames,
+  removeKeyframe as removeFrame,
+  upsertKeyframe as upsertFrame,
+} from './keyframe-editing';
 
 export const TIMELINE_SNAP_THRESHOLD_PX = 6;
 
 export function keyframeOffsetAtTime(time: number, animation: AnimationNode): number {
   const delay = finite(animation.delay, 0);
   const duration = Math.max(0.001, finite(animation.duration, 1));
-  return clamp((time - delay) / duration, 0, 1);
+  return offsetAtTime(time, delay, duration);
 }
 
 export function upsertKeyframe(
@@ -13,12 +19,7 @@ export function upsertKeyframe(
   offset: number,
   properties: Record<string, unknown>
 ): KeyframeNode[] {
-  const normalized = clamp(offset, 0, 1);
-  const frames = cloneKeyframes(animation.keyframes ?? []);
-  const existing = frames.find((frame) => Math.abs(frame.offset - normalized) < 0.0005);
-  if (existing) existing.properties = { ...existing.properties, ...properties };
-  else frames.push({ offset: normalized, properties: { ...properties } });
-  return sortKeyframes(frames);
+  return upsertFrame(animation.keyframes ?? [], offset, properties);
 }
 
 export function moveKeyframe(
@@ -26,17 +27,11 @@ export function moveKeyframe(
   currentOffset: number,
   nextOffset: number
 ): KeyframeNode[] {
-  const frames = cloneKeyframes(keyframes);
-  const frame = closestKeyframe(frames, currentOffset);
-  if (!frame) return frames;
-  frame.offset = clamp(nextOffset, 0, 1);
-  return sortKeyframes(frames);
+  return moveFrames(keyframes, currentOffset, nextOffset);
 }
 
 export function removeKeyframe(keyframes: KeyframeNode[], offset: number): KeyframeNode[] {
-  const frame = closestKeyframe(keyframes, offset);
-  if (!frame) return cloneKeyframes(keyframes);
-  return cloneKeyframes(keyframes).filter((candidate) => candidate.offset !== frame.offset);
+  return removeFrame(keyframes, offset);
 }
 
 export function snapTimelineTime(options: {
@@ -80,22 +75,6 @@ export function snapClipStart(options: {
     Math.abs(candidate) < Math.abs(best) ? candidate : best
   );
   return Math.abs(delta) <= threshold ? clamp(start + delta, 0, maxStart) : start;
-}
-
-function closestKeyframe(keyframes: KeyframeNode[], offset: number): KeyframeNode | undefined {
-  return keyframes.reduce<KeyframeNode | undefined>(
-    (best, frame) =>
-      !best || Math.abs(frame.offset - offset) < Math.abs(best.offset - offset) ? frame : best,
-    undefined
-  );
-}
-
-function cloneKeyframes(keyframes: KeyframeNode[]): KeyframeNode[] {
-  return keyframes.map((frame) => ({ offset: frame.offset, properties: { ...frame.properties } }));
-}
-
-function sortKeyframes(keyframes: KeyframeNode[]): KeyframeNode[] {
-  return keyframes.sort((left, right) => left.offset - right.offset);
 }
 
 function finite(value: unknown, fallback: number): number {

--- a/tests/ui/keyframe-editing.test.ts
+++ b/tests/ui/keyframe-editing.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  animatedProperties,
+  hasKeyframeProperties,
+  keyframeOffsetAtTime,
+  mergeCoincidentKeyframes,
   moveKeyframe,
+  removeKeyframeProperties,
   removeKeyframe,
   seedKeyframes,
   upsertKeyframe,
@@ -30,6 +35,18 @@ describe('AST keyframe editing', () => {
     expect(frames).toEqual([{ offset: 0.5, properties: { x: 10, y: 20 } }]);
   });
 
+  it('stores property values as independent snapshots', () => {
+    const value = { point: [100, 200] };
+    const first = upsertKeyframe([], 0, { value });
+    const second = upsertKeyframe(first, 0.5, { value });
+
+    value.point[0] = 999;
+    (second[1]?.properties['value'] as typeof value).point[1] = 888;
+
+    expect(first[0]?.properties['value']).toEqual({ point: [100, 200] });
+    expect(second[0]?.properties['value']).toEqual({ point: [100, 200] });
+  });
+
   it('moves frame offsets with clamping and stable sorting', () => {
     const frames = [
       { offset: 0, properties: { x: 0 } },
@@ -37,11 +54,36 @@ describe('AST keyframe editing', () => {
       { offset: 1, properties: { x: 100 } },
     ];
     expect(moveKeyframe(frames, 0.5, 0.8).map((frame) => frame.offset)).toEqual([0, 0.8, 1]);
-    expect(moveKeyframe(frames, 0.5, 2).map((frame) => frame.offset)).toEqual([0, 1, 1]);
+    expect(moveKeyframe(frames, 0.5, 2)).toEqual([
+      { offset: 0, properties: { x: 0 } },
+      { offset: 1, properties: { x: 50 } },
+    ]);
   });
 
   it('removes only the selected offset', () => {
     const frames = seedKeyframes([], { opacity: 0 }, { opacity: 1 });
     expect(removeKeyframe(frames, 0).map((frame) => frame.offset)).toEqual([1]);
+  });
+
+  it('tracks properties independently within composite frames', () => {
+    const frames = [
+      { offset: 0, properties: { x: 0, opacity: 0 } },
+      { offset: 0.5, properties: { opacity: 1 } },
+      { offset: 1, properties: { x: 100 } },
+    ];
+    expect(animatedProperties(frames)).toEqual(['x', 'opacity']);
+    expect(hasKeyframeProperties(frames, 0, ['x', 'opacity'])).toBe(true);
+    expect(hasKeyframeProperties(frames, 0.5, ['x'])).toBe(false);
+    expect(removeKeyframeProperties(frames, 0, ['opacity'])[0]?.properties).toEqual({ x: 0 });
+  });
+
+  it('maps playhead time and merges frames moved onto the same timestamp', () => {
+    expect(keyframeOffsetAtTime(3, 1, 4)).toBe(0.5);
+    expect(
+      mergeCoincidentKeyframes([
+        { offset: 0.5, properties: { x: 10 } },
+        { offset: 0.5, properties: { opacity: 0.5 } },
+      ])
+    ).toEqual([{ offset: 0.5, properties: { x: 10, opacity: 0.5 } }]);
   });
 });

--- a/tests/ui/keyframe-workflow.test.ts
+++ b/tests/ui/keyframe-workflow.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateScene } from '../../src/animation/evaluator';
+import { parseMotion } from '../../src/language/parser';
+import { serializeProgram } from '../../src/language/serializer';
+import { buildSceneGraph } from '../../src/scene/scene-graph';
+import type { AnimationNode } from '../../src/types/parser';
+import { moveKeyframe, removeKeyframe, upsertKeyframe } from '../../src/ui/keyframe-editing';
+
+const source = `
+canvas { size 100x100 fps 10 duration 4s background #000000 }
+text title { value "Title" x 0 y 0 scale 1 rotation 0 opacity 1 color #000000 }
+animate title {
+  keyframes {
+    0% { x 0 y 0 opacity 0 color #000000 }
+    50% { x 100 y 50 }
+    100% { x 200 y 100 opacity 1 color #ffffff }
+  }
+  duration 4s
+  easing linear
+}`;
+
+function animationFrom(project: ReturnType<typeof parseMotion>): AnimationNode {
+  const animation = project.body.find(
+    (node): node is AnimationNode => node.type === 'Animation' && node.target === 'title'
+  );
+  if (!animation) throw new Error('title animation missing');
+  return animation;
+}
+
+function titleAt(serialized: string, time: number) {
+  return evaluateScene(buildSceneGraph(parseMotion(serialized)), time).elements.find(
+    (element) => element.id === 'title'
+  )?.render;
+}
+
+describe('visual keyframe workflow', () => {
+  it('plays three position keyframes and independent opacity/color tracks', () => {
+    const middle = titleAt(source, 1);
+    const late = titleAt(source, 3);
+
+    expect(middle?.x).toBeCloseTo(50);
+    expect(middle?.y).toBeCloseTo(25);
+    expect(middle?.opacity).toBeCloseTo(0.25);
+    expect(String(middle?.color)).toContain('rgba(64, 64, 64');
+    expect(late?.x).toBeCloseTo(150);
+    expect(late?.opacity).toBeCloseTo(0.75);
+  });
+
+  it('adds an interpolated keyframe, edits its value, and moves its timing', () => {
+    const project = parseMotion(source);
+    const animation = animationFrom(project);
+    const beforeInsert = titleAt(serializeProgram(project), 1)?.x;
+
+    animation.keyframes = upsertKeyframe(animation.keyframes ?? [], 0.25, {
+      x: beforeInsert,
+      y: titleAt(serializeProgram(project), 1)?.y,
+    });
+    expect(titleAt(serializeProgram(project), 1)?.x).toBeCloseTo(Number(beforeInsert));
+
+    animation.keyframes = upsertKeyframe(animation.keyframes, 0.25, { x: 80 });
+    expect(titleAt(serializeProgram(project), 1)?.x).toBeCloseTo(80);
+
+    animation.keyframes = moveKeyframe(animation.keyframes, 0.25, 0.375);
+    const moved = serializeProgram(project);
+    expect(moved).toContain('37.5%');
+    expect(titleAt(moved, 1.5)?.x).toBeCloseTo(80);
+  });
+
+  it('deletes safely and persists all remaining keyframes through save/reload', () => {
+    const project = parseMotion(source);
+    const animation = animationFrom(project);
+    animation.keyframes = removeKeyframe(animation.keyframes ?? [], 0.5);
+
+    const saved = serializeProgram(project);
+    const reloaded = parseMotion(saved);
+    const frames = animationFrom(reloaded).keyframes ?? [];
+
+    expect(frames.map((frame) => frame.offset)).toEqual([0, 1]);
+    expect(titleAt(serializeProgram(reloaded), 2)?.x).toBeCloseTo(100);
+    expect(titleAt(serializeProgram(reloaded), 2)?.opacity).toBeCloseTo(0.5);
+  });
+
+  it('edits only the third of five keyframes and persists every value', () => {
+    const project = parseMotion(source);
+    const animation = animationFrom(project);
+    animation.keyframes = [0, 0.25, 0.5, 0.75, 1].map((offset, index) => ({
+      offset,
+      properties: { x: index * 100 },
+    }));
+
+    animation.keyframes = upsertKeyframe(animation.keyframes, 0.5, { x: 275 });
+
+    expect(animation.keyframes.map((frame) => frame.properties['x'])).toEqual([
+      0, 100, 275, 300, 400,
+    ]);
+    expect(titleAt(serializeProgram(project), 1)?.x).toBeCloseTo(100);
+    expect(titleAt(serializeProgram(project), 1.5)?.x).toBeCloseTo(187.5);
+
+    const reloaded = animationFrom(parseMotion(serializeProgram(project))).keyframes ?? [];
+    expect(reloaded.map((frame) => Number(frame.properties['x']))).toEqual([0, 100, 275, 300, 400]);
+  });
+});

--- a/tests/ui/motion-editor-components.test.ts
+++ b/tests/ui/motion-editor-components.test.ts
@@ -114,6 +114,7 @@ describe('motion editor leaf components', () => {
       target: host,
       props: {
         deleteToast: 'Deleted title',
+        keyframeNotice: 'Keyframe created',
         showConfirmDialog: true,
         onUndoDelete,
         onCancelPreset,
@@ -138,6 +139,7 @@ describe('motion editor leaf components', () => {
     expect(onUndoDelete).toHaveBeenCalledOnce();
     expect(onCancelPreset).toHaveBeenCalledOnce();
     expect(onConfirmPreset).toHaveBeenCalledOnce();
+    expect(host.querySelector('.me-keyframe-toast')?.textContent).toBe('Keyframe created');
 
     await unmount(instance);
   });
@@ -153,6 +155,7 @@ describe('MotionEditor integration', () => {
     vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
     vi.stubGlobal('cancelAnimationFrame', () => undefined);
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
 
     const host = target();
     const instance = mount(MotionEditor, {
@@ -183,6 +186,113 @@ describe('MotionEditor integration', () => {
     expect(contentPanelCss).toContain('.me-panel-content');
     expect(contentPanelCss).not.toMatch(/(^|[\s,{>+~])\.panel-content\b/m);
     expect(brandPanelSource).toMatch(/\.panel-content\s*\{[^}]*padding:\s*14px/s);
+
+    await unmount(instance);
+  });
+
+  it('creates and updates position keyframes through the visual controls', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 2s background #000000 }
+text title { value "Title" x 0 y 0 }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+
+    click(host.querySelector('.me-element-clip .me-clip-select'));
+    await tick();
+    click(host.querySelector('.me-keyframe-add'));
+    await tick();
+    expect(host.querySelector('.me-keyframe-add')).toBeNull();
+
+    const scrubber = host.querySelector<HTMLInputElement>('.me-timeline-scrubber');
+    if (!scrubber) throw new Error('Timeline scrubber missing');
+    scrubber.value = '1';
+    scrubber.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+
+    const scaleInput = host.querySelector<HTMLInputElement>('[aria-label="Scale value"]');
+    if (!scaleInput) throw new Error('Scale input missing');
+    scaleInput.value = '2';
+    scaleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+
+    expect(host.querySelectorAll('.me-keyframe-marker')).toHaveLength(2);
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const beforeDelete = host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value ?? '';
+    expect(beforeDelete).toContain('50%');
+    expect(beforeDelete).toContain('scale 2');
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+
+    click(host.querySelector('[aria-label="Keyframe at 50 percent"]'));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+    await tick();
+    expect(host.querySelectorAll('.me-keyframe-marker')).toHaveLength(1);
+
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const serialized = host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value ?? '';
+    expect(serialized).toContain('0%');
+    expect(serialized).not.toContain('50%');
+    expect(serialized).not.toContain('scale 2');
+
+    await unmount(instance);
+  });
+
+  it('shows the evaluated scale while the playhead moves between keyframes', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 2s background #000000 }
+text title { value "Title" x 0 y 0 scale 1 }
+animate title {
+  keyframes {
+    0% { scale 1 }
+    100% { scale 2 }
+  }
+  duration 2s
+  easing linear
+}`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+
+    click(host.querySelector('.me-element-clip .me-clip-select'));
+    const scrubber = host.querySelector<HTMLInputElement>('.me-timeline-scrubber');
+    if (!scrubber) throw new Error('Timeline scrubber missing');
+    scrubber.value = '1';
+    scrubber.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Scale"]')?.value).toBe('1.5');
+    expect(host.querySelector<HTMLInputElement>('[aria-label="Scale value"]')?.value).toBe('1.50');
 
     await unmount(instance);
   });


### PR DESCRIPTION
## Summary

- store keyframes as independent immutable snapshots
- update only the keyframe at the current playhead position
- interpolate each animated property between its surrounding keyframes
- support reliable keyframe creation, movement, selection, and deletion
- synchronize the scale slider and numeric value with the evaluated playhead state
- preserve keyframe values through `.motion` save and reload

## Testing

- added five-keyframe isolation and persistence coverage
- added scale interpolation and inspector synchronization coverage
- TypeScript check passes
- focused keyframe/editor tests pass
- production build passes