### PR TITLE
fix(editor): collapse drag gestures into single undo steps

### DIFF
--- a/src/ui/components/ColorPicker.svelte
+++ b/src/ui/components/ColorPicker.svelte
@@ -4,6 +4,8 @@
   export let value = '#ffffff';
   export let ariaLabel = 'Color';
   export let onChange: (color: string) => void = () => undefined;
+  export let onDragStart: () => void = () => undefined;
+  export let onDragEnd: () => void = () => undefined;
 
   let root: HTMLDivElement;
   let open = false;
@@ -34,6 +36,17 @@
   function selectColor(color: string) {
     onChange(normalizeColor(color));
     open = false;
+  }
+
+  // Live drag in the native OS color dialog: preview on every input, but collapse
+  // the whole drag into a single undo step via the drag brackets.
+  function previewColor(color: string) {
+    onDragStart();
+    onChange(normalizeColor(color));
+  }
+
+  function commitColor() {
+    onDragEnd();
   }
 
   function commitHex(event: Event) {
@@ -84,7 +97,7 @@
         />
         <label class="custom-color" title="Choose a custom color" aria-label="Choose a custom color">
           <Pipette size={14} />
-          <input type="color" value={normalizedValue} on:input={(event) => selectColor(event.currentTarget.value)} />
+          <input type="color" value={normalizedValue} on:input={(event) => previewColor(event.currentTarget.value)} on:change={commitColor} />
         </label>
       </div>
 

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -1161,6 +1161,8 @@
     target.setPointerCapture?.(event.pointerId);
     document.body.style.cursor = 'ns-resize';
     document.body.style.userSelect = 'none';
+    // Bracket the whole scrub gesture into one undo step.
+    beginHistoryGesture();
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const sensitivity = moveEvent.shiftKey ? 0.1 : 0.5;
@@ -1176,6 +1178,7 @@
       if (target.hasPointerCapture?.(event.pointerId)) target.releasePointerCapture(event.pointerId);
       document.body.style.cursor = previousCursor;
       document.body.style.userSelect = previousSelection;
+      endHistoryGesture();
     };
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', finishScrub);
@@ -1239,6 +1242,8 @@
           const centerX = bounds.x + bounds.width / 2;
           const centerY = bounds.y + bounds.height / 2;
           const visualId = selectedClip?.id ?? selectedVisual.id;
+          // Bracket the whole resize gesture into one undo step.
+          beginHistoryGesture();
           dragState = {
             mode: 'resize',
             id: selectedAnimationTarget() || selectedVisual.id,
@@ -1269,6 +1274,8 @@
     if (!target) return;
     const sourceTarget = scene.clips.find((clip) => clip.id === targetId)?.assetName ?? targetId;
     const center = elementCenter(target);
+    // Bracket the whole move gesture into one undo step.
+    beginHistoryGesture();
     dragState = {
       mode: 'move',
       id: sourceTarget,
@@ -1327,6 +1334,9 @@
   function handleCanvasPointerUp(event: PointerEvent) {
     dragState = null;
     snapGuides = { vertical: null, horizontal: null };
+    // Collapse the move/resize gesture into a single undo entry (a no-op click
+    // records nothing because the source never changed).
+    endHistoryGesture();
     if (canvas.hasPointerCapture(event.pointerId)) {
       canvas.releasePointerCapture(event.pointerId);
     }
@@ -2956,6 +2966,8 @@
       {isPropertyAnimated}
       {hasPropertyKeyframeAtPlayhead}
       onUpdateElementProperty={updateElementProperty}
+      onGestureStart={beginHistoryGesture}
+      onGestureEnd={endHistoryGesture}
       onTogglePropertyKeyframe={togglePropertyKeyframe}
       onBeginPropertyScrub={beginPropertyScrub}
       onPropertyScrubKey={handlePropertyScrubKey}

--- a/src/ui/components/RotationDial.svelte
+++ b/src/ui/components/RotationDial.svelte
@@ -4,6 +4,8 @@
   export let value = 0;
   export let ariaLabel = 'Rotation';
   export let onChange: (angle: number) => void = () => undefined;
+  export let onDragStart: () => void = () => undefined;
+  export let onDragEnd: () => void = () => undefined;
 
   let dial: HTMLDivElement;
   let dragging = false;
@@ -52,6 +54,7 @@
     if (event.button !== 0) return;
     event.preventDefault();
     dragging = true;
+    onDragStart();
     dial.setPointerCapture(event.pointerId);
     updateFromPointer(event);
   }
@@ -61,8 +64,10 @@
   }
 
   function endDrag(event: PointerEvent) {
+    if (!dragging) return;
     dragging = false;
     if (dial.hasPointerCapture(event.pointerId)) dial.releasePointerCapture(event.pointerId);
+    onDragEnd();
   }
 
   function toggleFlip() {

--- a/src/ui/components/motion-editor/PropertiesInspector.svelte
+++ b/src/ui/components/motion-editor/PropertiesInspector.svelte
@@ -33,6 +33,8 @@
   export let isPropertyAnimated: (properties: string[]) => boolean;
   export let hasPropertyKeyframeAtPlayhead: (properties: string[]) => boolean;
   export let onUpdateElementProperty: (key: string, value: string | number | boolean) => void;
+  export let onGestureStart: () => void = () => undefined;
+  export let onGestureEnd: () => void = () => undefined;
   export let onTogglePropertyKeyframe: (properties: string[]) => void;
   export let onBeginPropertyScrub: (event: PointerEvent, key: string, fallback: number, minimum?: number) => void;
   export let onPropertyScrubKey: (event: KeyboardEvent, key: string, fallback: number, minimum?: number) => void;
@@ -131,7 +133,7 @@
               <div class="me-property-label">Rotation</div>
               <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['rotation'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['rotation'])} on:click={() => onTogglePropertyKeyframe(['rotation'])} title="Toggle rotation keyframe at playhead" aria-label="Toggle rotation keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['rotation'])}><Diamond size={11} fill="currentColor" /></button>
             </div>
-            <RotationDial value={selectedVisualProperty('rotation', 0)} onChange={(angle) => onUpdateElementProperty('rotation', angle)} />
+            <RotationDial value={selectedVisualProperty('rotation', 0)} onChange={(angle) => onUpdateElementProperty('rotation', angle)} onDragStart={onGestureStart} onDragEnd={onGestureEnd} />
           </div>
           {#if selectedElement.kind === 'text'}
             <div class="me-property-group">
@@ -183,12 +185,16 @@
                 value={selectedVisualStringProperty('color', '#ffffff')}
                 ariaLabel="Text color"
                 onChange={(color) => onUpdateElementProperty('color', color)}
+                onDragStart={onGestureStart}
+                onDragEnd={onGestureEnd}
               />
             {:else if selectedElement.kind === 'overlay' || selectedElement.asset?.type === 'svg'}
               <ColorPicker
                 value={selectedVisualStringProperty('fill', '#ffffff')}
                 ariaLabel="Layer color"
                 onChange={(color) => onUpdateElementProperty('fill', color)}
+                onDragStart={onGestureStart}
+                onDragEnd={onGestureEnd}
               />
             {:else}
               <div class="me-property-unavailable">Uses source media colors</div>
@@ -264,6 +270,8 @@
                 value={stringProperty(selectedElement, 'stroke', '#ffffff')}
                 ariaLabel="SVG stroke color"
                 onChange={(color) => onUpdateElementProperty('stroke', color)}
+                onDragStart={onGestureStart}
+                onDragEnd={onGestureEnd}
               />
             </div>
           {/if}
@@ -507,7 +515,7 @@
               <div class="me-property-label">Rotation</div>
               <button type="button" class="me-property-keyframe" class:me-animated-property={isPropertyAnimated(['rotation'])} class:me-keyframe-at-playhead={hasPropertyKeyframeAtPlayhead(['rotation'])} on:click={() => onTogglePropertyKeyframe(['rotation'])} title="Toggle rotation keyframe at playhead" aria-label="Toggle rotation keyframe at playhead" aria-pressed={hasPropertyKeyframeAtPlayhead(['rotation'])}><Diamond size={11} fill="currentColor" /></button>
             </div>
-            <RotationDial value={selectedVisualProperty('rotation', 0)} onChange={(angle) => onUpdateElementProperty('rotation', angle)} />
+            <RotationDial value={selectedVisualProperty('rotation', 0)} onChange={(angle) => onUpdateElementProperty('rotation', angle)} onDragStart={onGestureStart} onDragEnd={onGestureEnd} />
           </div>
           <p class="me-shared-property-note">Visual changes apply to every clip using this source asset.</p>
           <div class="me-property-group">
@@ -542,6 +550,8 @@
                 value={selectedVisualStringProperty('fill', '#ffffff')}
                 ariaLabel="Clip color"
                 onChange={(color) => onUpdateElementProperty('fill', color)}
+                onDragStart={onGestureStart}
+                onDragEnd={onGestureEnd}
               />
             {:else}
               <div class="me-property-unavailable">Uses source media colors</div>


### PR DESCRIPTION
## Summary

Fixes broken undo/redo for continuous editing gestures. Dragging an object,
resizing it, scrubbing a numeric field, spinning the rotation dial, or dragging
a color previously created one undo entry per pointermove — so a single drag
could take dozens of Ctrl+Z presses to reverse.

Now each continuous gesture collapses into exactly one undo step, matching the
pattern the timeline handlers already used (beginHistoryGesture / endHistoryGesture).

## Root cause

The timeline trim/move/keyframe handlers correctly bracketed their gestures,
but five canvas/property editors did not, so every intermediate source
serialization was recorded as a separate history entry.

## Changes

- **MotionEditor.svelte** — bracket canvas move drag, canvas resize drag, and
property scrubbing; wire gesture callbacks into PropertiesInspector.
- **RotationDial.svelte** — add optional `onDragStart`/`onDragEnd`, fired around
the dial drag.
- **ColorPicker.svelte** — add optional `onDragStart`/`onDragEnd`; native color
input previews live on `input` and commits a single undo step on `change`.
- **PropertiesInspector.svelte** — forward `onGestureStart`/`onGestureEnd` to the
rotation dial and all four color pickers.