### PR TITLE
fix(editor): improve asset selection, deletion, views, and panel resi…

### DIFF
--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -157,6 +157,7 @@
   let audioClipDuration = 0;
   let visibleWaveformPeaks = 1;
   let timelineHeight = 230;
+  let contentPanelWidth = 260;
   let mp4Supported = false;
   let isExporting = false;
   let exportError = '';
@@ -167,6 +168,11 @@
   let mediaSubTab: 'assets' | 'presets' = 'assets';
   let showConfirmDialog = false;
   let pendingPresetPath = '';
+  let pendingDelete:
+    | { kind: 'assets'; assets: Asset[]; usageCount: number }
+    | { kind: 'audio' }
+    | { kind: 'text'; ids: string[] }
+    | null = null;
   let previewAsset: AssetPreview | null = null;
   let videoRenderId = 0;
   let isDraggingUpload = false;
@@ -339,6 +345,26 @@
   function cancelLoadPreset() {
     showConfirmDialog = false;
     pendingPresetPath = '';
+  }
+
+  function cancelConfirmDialog() {
+    if (pendingDelete) pendingDelete = null;
+    else cancelLoadPreset();
+    showConfirmDialog = false;
+  }
+
+  function confirmDialog() {
+    if (!pendingDelete) return confirmLoadPreset();
+    const deletion = pendingDelete;
+    pendingDelete = null;
+    showConfirmDialog = false;
+    if (deletion.kind === 'assets') {
+      for (const asset of deletion.assets) removeAssetNow(asset);
+    } else if (deletion.kind === 'audio') {
+      removeAudio();
+    } else {
+      for (const id of deletion.ids) deleteElement(id);
+    }
   }
 
   function loadGeneratedMotion(source: string): string | null {
@@ -717,6 +743,21 @@
 
   function toggleCodeEditor() {
     showCodeEditor = !showCodeEditor;
+  }
+
+  function resizeContentPanel(event: PointerEvent) {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = contentPanelWidth;
+    const move = (pointer: PointerEvent) => {
+      contentPanelWidth = Math.min(420, Math.max(220, startWidth + pointer.clientX - startX));
+    };
+    const stop = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', stop);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', stop);
   }
 
 
@@ -1402,7 +1443,62 @@
     }
   }
 
+  function requestRemoveAssets(selectedAssets: Asset[]) {
+    if (!ast || !selectedAssets.length) return;
+    pendingDelete = {
+      kind: 'assets',
+      assets: selectedAssets,
+      usageCount: selectedAssets.reduce((total, asset) => total + assetUsage(asset).usageCount, 0),
+    };
+    showConfirmDialog = true;
+  }
 
+  function requestRemoveAudio() {
+    if (!audioName) return;
+    pendingDelete = { kind: 'audio' };
+    showConfirmDialog = true;
+  }
+
+  function requestRemoveElements(ids: string[]) {
+    if (!ids.length) return;
+    pendingDelete = { kind: 'text', ids };
+    showConfirmDialog = true;
+  }
+
+  function assetUsage(asset: Asset) {
+    const elementNames = new Set(
+      ast.body.flatMap((node) =>
+        node.type === 'Element' &&
+        ((node.kind === 'asset' && node.name === asset.name) ||
+          (node.kind === 'image' && node.properties['source'] === asset.name))
+          ? [node.name]
+          : []
+      )
+    );
+    const usageCount =
+      elementNames.size +
+      ast.body.filter((node) => node.type === 'Clip' && node.assetName === asset.name).length;
+    return { elementNames, usageCount };
+  }
+
+  function removeAssetNow(asset: Asset) {
+    if (!ast) return;
+    const { elementNames } = assetUsage(asset);
+    const previousSource = code;
+    ast.body = ast.body.filter(
+      (node) =>
+        !(node.type === 'Import' && node.name === asset.name) &&
+        !(node.type === 'Clip' && node.assetName === asset.name) &&
+        !(node.type === 'Element' && elementNames.has(node.name)) &&
+        !(node.type === 'Animation' && elementNames.has(node.target))
+    );
+    embeddedAssets = embeddedAssets.filter((item) => item.name !== asset.name);
+    selectedElementId = '';
+    previewAsset = null;
+    const resultSource = serializeProgram(ast);
+    code = resultSource;
+    showDeletedToast('Asset removed', previousSource, resultSource);
+  }
 
   function clearAssetPreview() {
     previewAsset = null;
@@ -2873,7 +2969,7 @@
 
 <div class="motion-editor-scope" style={`--timeline-height: ${timelineHeight}px`}>
 <div class="me-motion-editor" class:me-fullscreen={isFullscreen} style={`--timeline-height: ${timelineHeight}px`}>
-  <div class="me-workbench" class:me-chat-open={showAiChat}>
+  <div class="me-workbench" class:me-chat-open={showAiChat} style={`--content-panel-width: ${contentPanelWidth}px`}>
     <NavigationRail activeTab={activeNavTab} onSelect={(tab) => (activeNavTab = tab)} />
 
     <ContentPanel
@@ -2902,14 +2998,17 @@
       onAssetDragStart={handleAssetDragStart}
       onAssetDragEnd={handleAssetDragEnd}
       onPreviewAsset={previewAssetOnly}
+      onRemoveAssets={requestRemoveAssets}
       onRequestPresetLoad={requestPresetLoad}
-      onRemoveAudio={removeAudio}
+      onRequestRemoveAudio={requestRemoveAudio}
       onAddTextElement={addTextElement}
       onSelectElement={selectElement}
+      onRemoveElements={requestRemoveElements}
       {canApplyLibraryPreset}
       onApplyLibraryPreset={applyLibraryPreset}
       onTransitionDragStart={handleTransitionDragStart}
       onTransitionDragEnd={handleTransitionDragEnd}
+      onResizeStart={resizeContentPanel}
     />
 
     <aside class="me-chat-drawer" class:me-collapsed={!showAiChat}>
@@ -3078,8 +3177,25 @@
   {deleteToast}
   {keyframeNotice}
   {showConfirmDialog}
+  dialogTitle={pendingDelete?.kind === 'assets'
+    ? 'Delete Asset'
+    : pendingDelete?.kind === 'audio'
+      ? 'Delete Audio'
+      : pendingDelete?.kind === 'text'
+        ? 'Delete Text'
+        : 'Load Preset'}
+  dialogMessage={pendingDelete?.kind === 'assets'
+    ? pendingDelete.assets.length === 1
+      ? `${pendingDelete.assets[0].name} is used ${pendingDelete.usageCount} time${pendingDelete.usageCount === 1 ? '' : 's'}. Delete it and its timeline items?`
+      : `Delete ${pendingDelete.assets.length} selected assets and their timeline items?`
+    : pendingDelete?.kind === 'audio'
+      ? `Delete ${audioName} and remove it from the timeline?`
+      : pendingDelete?.kind === 'text'
+        ? `Delete ${pendingDelete.ids.length === 1 ? pendingDelete.ids[0] : `${pendingDelete.ids.length} selected text layers`}?`
+        : 'Loading this preset will replace your current project and assets. Continue?'}
+  dialogConfirmLabel={pendingDelete ? 'Delete' : 'Load Preset'}
   onUndoDelete={undoDelete}
-  onCancelPreset={cancelLoadPreset}
-  onConfirmPreset={confirmLoadPreset}
+  onCancelDialog={cancelConfirmDialog}
+  onConfirmDialog={confirmDialog}
 />
 </div>

--- a/src/ui/components/motion-editor/ContentPanel.svelte
+++ b/src/ui/components/motion-editor/ContentPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './content-panel.css';
-  import { FileImage, Maximize2, Music2, Plus, Sparkles, Square, Trash2, Type, Upload, Wand2 } from 'lucide-svelte';
+  import { CloudUpload, FileImage, LayoutGrid, List, Maximize2, Music2, Plus, Sparkles, Square, Trash2, Type, Upload, Wand2 } from 'lucide-svelte';
   import type { LoadedAsset } from '../../../assets/asset-loader';
   import type { Asset, Element, Scene } from '../../../types/scene';
   import AiConfigPanel from '../AiConfigPanel.svelte';
@@ -34,17 +34,127 @@
   export let onAssetDragStart: (event: DragEvent, asset: Asset) => void;
   export let onAssetDragEnd: () => void;
   export let onPreviewAsset: (asset: Asset) => void;
+  export let onRemoveAssets: (assets: Asset[]) => void;
   export let onRequestPresetLoad: (path: string) => void;
-  export let onRemoveAudio: () => void;
+  export let onRequestRemoveAudio: () => void;
   export let onAddTextElement: () => void;
   export let onSelectElement: (id: string) => void;
+  export let onRemoveElements: (ids: string[]) => void;
   export let canApplyLibraryPreset: (preset: AnimationPresetDef) => boolean;
   export let onApplyLibraryPreset: (preset: AnimationPresetDef) => void;
   export let onTransitionDragStart: (event: DragEvent) => void;
   export let onTransitionDragEnd: () => void;
+  export let onResizeStart: (event: PointerEvent) => void;
+
+  let selectedAssetNames = new Set<string>();
+  let assetView: 'grid' | 'list' = 'grid';
+  let audioSelected = false;
+  let selectedTextIds = new Set<string>();
+  let assetSelectionAnchor = '';
+  let textSelectionAnchor = '';
+  let selectionContext = '';
+  $: selectedAssets = scene?.imports.filter((asset) => selectedAssetNames.has(asset.name)) ?? [];
+  $: textElements = sourceElements.filter((element) => element.kind === 'text');
+  $: selectedTextElements = textElements.filter((element) => selectedTextIds.has(element.id));
+  $: {
+    const nextContext = `${activeNavTab}:${mediaSubTab}`;
+    if (selectionContext && selectionContext !== nextContext) clearSelections();
+    selectionContext = nextContext;
+  }
+
+  function clearSelections() {
+    selectedAssetNames = new Set();
+    assetSelectionAnchor = '';
+    selectedTextIds = new Set();
+    textSelectionAnchor = '';
+    audioSelected = false;
+  }
+
+  function handleSelectionKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') clearSelections();
+  }
+
+  function selectAsset(asset: Asset, event: MouseEvent) {
+    if (event.shiftKey) {
+      selectAssetRange(asset, event);
+      return;
+    }
+    if (event.ctrlKey || event.metaKey) {
+      selectedAssetNames = new Set(selectedAssetNames);
+      if (selectedAssetNames.has(asset.name)) selectedAssetNames.delete(asset.name);
+      else selectedAssetNames.add(asset.name);
+    } else {
+      selectedAssetNames = new Set([asset.name]);
+    }
+    assetSelectionAnchor = asset.name;
+    onPreviewAsset(asset);
+  }
+
+  function selectAssetRange(asset: Asset, event: MouseEvent) {
+    if (!event.shiftKey) return;
+    event.preventDefault();
+    const imports = scene?.imports ?? [];
+    const anchorIndex = imports.findIndex((item) => item.name === assetSelectionAnchor);
+    const targetIndex = imports.findIndex((item) => item.name === asset.name);
+    if (anchorIndex < 0 || targetIndex < 0) {
+      selectedAssetNames = new Set([asset.name]);
+      assetSelectionAnchor = asset.name;
+    } else {
+      const start = Math.min(anchorIndex, targetIndex);
+      const end = Math.max(anchorIndex, targetIndex);
+      selectedAssetNames = new Set(imports.slice(start, end + 1).map((item) => item.name));
+    }
+    onPreviewAsset(asset);
+  }
+
+  function removeSelectedText() {
+    onRemoveElements(selectedTextElements.map((element) => element.id));
+    selectedTextIds = new Set();
+  }
+
+  function selectText(element: Element, event: MouseEvent) {
+    if (event.shiftKey) {
+      selectTextRange(element, event);
+      return;
+    }
+    if (event.ctrlKey || event.metaKey) {
+      selectedTextIds = new Set(selectedTextIds);
+      if (selectedTextIds.has(element.id)) selectedTextIds.delete(element.id);
+      else selectedTextIds.add(element.id);
+    } else {
+      selectedTextIds = new Set([element.id]);
+    }
+    textSelectionAnchor = element.id;
+    onSelectElement(element.id);
+  }
+
+  function selectTextRange(element: Element, event: MouseEvent) {
+    if (!event.shiftKey) return;
+    event.preventDefault();
+    const anchorIndex = textElements.findIndex((item) => item.id === textSelectionAnchor);
+    const targetIndex = textElements.findIndex((item) => item.id === element.id);
+    if (anchorIndex < 0 || targetIndex < 0) {
+      selectedTextIds = new Set([element.id]);
+      textSelectionAnchor = element.id;
+    } else {
+      const start = Math.min(anchorIndex, targetIndex);
+      const end = Math.max(anchorIndex, targetIndex);
+      selectedTextIds = new Set(textElements.slice(start, end + 1).map((item) => item.id));
+    }
+    onSelectElement(element.id);
+  }
 </script>
 
+<svelte:window on:keydown={handleSelectionKeydown} />
+
 <aside class="me-content-panel">
+      <button
+        type="button"
+        class="me-panel-resize-handle"
+        aria-label="Resize asset panel"
+        title="Drag to resize panel"
+        on:pointerdown={onResizeStart}
+      ></button>
       {#if activeNavTab === 'media'}
         <div class="me-panel-header">
           <div class="me-panel-tabs">
@@ -68,8 +178,18 @@
           {#if mediaSubTab === 'assets'}
             <div class="me-panel-header-actions">
               <input bind:this={assetInput} class="me-file-input" type="file" accept="image/*,video/*,.svg,.gif,.mp4,.webm,.mov,.m4v,.lottie" multiple on:change={onAssetUpload} />
-              <button type="button" class="me-header-icon-btn" on:click={() => assetInput.click()} title="Import media" aria-label="Import media">
-                <Plus size={15} />
+              <button
+                type="button"
+                class="me-header-icon-btn"
+                title={`Show ${assetView === 'grid' ? 'list' : 'grid'} view`}
+                aria-label={`Show ${assetView === 'grid' ? 'list' : 'grid'} view`}
+                on:click={() => (assetView = assetView === 'grid' ? 'list' : 'grid')}
+              >
+                {#if assetView === 'grid'}<List size={15} />{:else}<LayoutGrid size={15} />{/if}
+              </button>
+              <button type="button" class="me-import-header-btn" on:click={() => assetInput.click()} title="Import media" aria-label="Import media">
+                <CloudUpload size={14} />
+                <span>Import</span>
               </button>
             </div>
           {/if}
@@ -88,7 +208,7 @@
             >
               {#if assetError}<p class="me-asset-error">{assetError}</p>{/if}
               {#if !assetsReady}<p class="me-status-label" role="status"><span></span> Loading media previews…</p>{/if}
-              {#if !scene?.audio && scene?.imports.length === 0}
+              {#if scene?.imports.length === 0}
                 <div class="me-library-empty-state">
                   <span class="me-library-empty-icon"><Upload size={18} /></span>
                   <strong>Add your first asset</strong>
@@ -99,35 +219,6 @@
                   <small>Images, video, SVG, GIF and Lottie</small>
                 </div>
               {/if}
-            <!-- Audio Section -->
-            {#if scene?.audio}
-              <div class="me-asset-folder">
-                <div class="me-folder-header">
-                  <Music2 size={14} />
-                  <span class="me-folder-title">Audio</span>
-                </div>
-                <div class="me-folder-content">
-                  <div
-                    class="me-asset-item me-audio-asset"
-                    role="button"
-                    tabindex="0"
-                    draggable="true"
-                    aria-label={`Drag ${audioName || 'audio'} to the timeline`}
-                    on:dragstart={onAudioDragStart}
-                    on:dragend={onAudioDragEnd}
-                  >
-                    <div class="me-asset-item-icon">
-                      <Music2 size={16} />
-                    </div>
-                    <div class="me-asset-item-info">
-                      <div class="me-asset-item-name">{scene.audio.substring(scene.audio.lastIndexOf('/') + 1)}</div>
-                      <div class="me-asset-item-path">{scene.audio}</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            {/if}
-
             <!-- Visual Assets Section -->
             {#if scene && scene.imports.length > 0}
               <div class="me-asset-folder">
@@ -135,30 +226,51 @@
                   <FileImage size={14} />
                   <span class="me-folder-title">Media</span>
                   <span class="me-folder-count">{scene.imports.length}</span>
-                </div>
-                <div class="me-asset-grid">
-                  {#each scene.imports as asset}
+                  {#if selectedAssets.length}
                     <button
                       type="button"
-                      class="me-asset-card"
-                      draggable={assets.has(asset.name)}
-                      on:click={() => onPreviewAsset(asset)}
-                      on:dragstart={(e) => onAssetDragStart(e, asset)}
-                      on:dragend={onAssetDragEnd}
+                      class="me-folder-delete"
+                      title={`Delete selected asset${selectedAssets.length === 1 ? '' : 's'}`}
+                      aria-label={`Delete selected asset${selectedAssets.length === 1 ? '' : 's'}`}
+                      on:click={() => {
+                        onRemoveAssets(selectedAssets);
+                        selectedAssetNames = new Set();
+                      }}
                     >
-                      <div class="me-asset-thumbnail">
-                        {#if asset.type === 'video'}
-                          <video src={assetPreviewSource(assets.get(asset.name), asset.path)} muted playsinline preload="metadata"></video>
-                        {:else if asset.path}
-                          <img src={assetPreviewSource(assets.get(asset.name), asset.path)} alt={asset.name} />
-                        {:else}
-                          <FileImage size={24} />
-                        {/if}
-                      </div>
-                      <div class="me-asset-info">
-                        <div class="me-asset-name">{asset.name}</div>
-                      </div>
+                      <Trash2 size={14} />
                     </button>
+                  {/if}
+                </div>
+                <div class="me-asset-grid" class:me-list-view={assetView === 'list'}>
+                  {#each scene.imports as asset}
+                    <div
+                      class="me-asset-card-wrap"
+                      class:me-selected={selectedAssetNames.has(asset.name)}
+                    >
+                      <button
+                        type="button"
+                        class="me-asset-card"
+                        draggable={assets.has(asset.name)}
+                        aria-label={`Select and preview ${asset.name}`}
+                        on:click={(event) => selectAsset(asset, event)}
+                        on:contextmenu={(event) => selectAssetRange(asset, event)}
+                        on:dragstart={(e) => onAssetDragStart(e, asset)}
+                        on:dragend={onAssetDragEnd}
+                      >
+                        <div class="me-asset-thumbnail">
+                          {#if asset.type === 'video'}
+                            <video src={assetPreviewSource(assets.get(asset.name), asset.path)} muted playsinline preload="metadata"></video>
+                          {:else if asset.path}
+                            <img src={assetPreviewSource(assets.get(asset.name), asset.path)} alt={asset.name} />
+                          {:else}
+                            <FileImage size={24} />
+                          {/if}
+                        </div>
+                        <div class="me-asset-info">
+                          <div class="me-asset-name">{asset.name}</div>
+                        </div>
+                      </button>
+                    </div>
                   {/each}
                 </div>
               </div>
@@ -188,6 +300,20 @@
         <div class="me-panel-header">
           <h3 class="me-panel-heading-title">Audio</h3>
           <div class="me-panel-header-actions">
+            {#if audioSelected && audioName}
+              <button
+                type="button"
+                class="me-folder-delete"
+                title="Delete selected audio"
+                aria-label="Delete selected audio"
+                on:click={() => {
+                  onRequestRemoveAudio();
+                  audioSelected = false;
+                }}
+              >
+                <Trash2 size={14} />
+              </button>
+            {/if}
             <button type="button" class="me-header-icon-btn" on:click={() => audioInput.click()} title="Import audio">
               <Upload size={16} />
             </button>
@@ -208,16 +334,20 @@
             {#if audioName}
               <div
                 class="me-audio-item me-audio-asset"
+                class:me-selected={audioSelected}
                 role="button"
                 tabindex="0"
                 draggable="true"
-                aria-label={`Drag ${audioName} to the timeline`}
+                aria-label={`Select or drag ${audioName}`}
+                on:click={() => (audioSelected = true)}
+                on:keydown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') audioSelected = true;
+                }}
                 on:dragstart={onAudioDragStart}
                 on:dragend={onAudioDragEnd}
               >
                 <Music2 size={18} />
                 <span>{audioName}</span>
-                <button class="me-icon-btn" on:click={onRemoveAudio} title="Remove audio"><Trash2 size={14} /></button>
               </div>
             {:else}
               <div class="me-library-empty-state">
@@ -236,6 +366,17 @@
         <div class="me-panel-header">
           <h3 class="me-panel-heading-title">Text</h3>
           <div class="me-panel-header-actions">
+            {#if selectedTextElements.length}
+              <button
+                type="button"
+                class="me-folder-delete"
+                title={`Delete selected text${selectedTextElements.length === 1 ? '' : ' layers'}`}
+                aria-label={`Delete selected text${selectedTextElements.length === 1 ? '' : ' layers'}`}
+                on:click={removeSelectedText}
+              >
+                <Trash2 size={14} />
+              </button>
+            {/if}
             <button type="button" class="me-header-icon-btn" on:click={onAddTextElement} title="Add text">
               <Plus size={16} />
             </button>
@@ -243,21 +384,28 @@
         </div>
         <div class="me-panel-content">
           <div class="me-layer-list">
-            {#each sourceElements.filter(el => el.kind === 'text') as element}
-              <button
-                type="button"
-                class="me-layer-row"
-                class:me-selected={selectedElementId === element.id}
-                on:click={() => onSelectElement(element.id)}
+            {#each textElements as element}
+              <div
+                class="me-layer-row-wrap"
+                class:me-checked={selectedTextIds.has(element.id)}
               >
-                <span class="me-layer-icon">
-                  <Type size={14} />
-                </span>
-                <span class="me-layer-copy">
-                  <strong>{element.id}</strong>
-                  <small>{elementDetail(element)}</small>
-                </span>
-              </button>
+                <button
+                  type="button"
+                  class="me-layer-row"
+                  class:me-selected={selectedElementId === element.id}
+                  aria-label={`Select ${element.id}`}
+                  on:click={(event) => selectText(element, event)}
+                  on:contextmenu={(event) => selectTextRange(element, event)}
+                >
+                  <span class="me-layer-icon">
+                    <Type size={14} />
+                  </span>
+                  <span class="me-layer-copy">
+                    <strong>{element.id}</strong>
+                    <small>{elementDetail(element)}</small>
+                  </span>
+                </button>
+              </div>
             {/each}
           </div>
         </div>
@@ -369,4 +517,3 @@
         <BrandConfigPanel assetList={assistantAssets} />
       {/if}
     </aside>
-

--- a/src/ui/components/motion-editor/EditorFeedback.svelte
+++ b/src/ui/components/motion-editor/EditorFeedback.svelte
@@ -5,10 +5,22 @@
   export let deleteToast: string;
   export let keyframeNotice: string;
   export let showConfirmDialog: boolean;
+  export let dialogTitle: string;
+  export let dialogMessage: string;
+  export let dialogConfirmLabel: string;
   export let onUndoDelete: () => void;
-  export let onCancelPreset: () => void;
-  export let onConfirmPreset: () => void | Promise<void>;
+  export let onCancelDialog: () => void;
+  export let onConfirmDialog: () => void | Promise<void>;
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (showConfirmDialog && event.key === 'Escape') {
+      event.preventDefault();
+      onCancelDialog();
+    }
+  }
 </script>
+
+<svelte:window on:keydown={handleWindowKeydown} />
 
 {#if deleteToast}
   <div class="me-delete-toast" role="status" aria-live="polite">
@@ -23,20 +35,20 @@
 {/if}
 
 {#if showConfirmDialog}
-  <div class="me-dialog-overlay" on:click={onCancelPreset} on:keydown={(event) => event.key === 'Escape' && onCancelPreset()} role="button" tabindex="-1">
-    <div class="me-dialog" on:click|stopPropagation on:keydown={(event) => event.key === 'Enter' && onConfirmPreset()} role="dialog" aria-labelledby="dialog-title" aria-modal="true" tabindex="0">
+  <div class="me-dialog-overlay" on:click={onCancelDialog} on:keydown={() => undefined} role="button" tabindex="-1">
+    <div class="me-dialog" on:click|stopPropagation on:keydown={(event) => event.key === 'Enter' && onConfirmDialog()} role="dialog" aria-labelledby="dialog-title" aria-modal="true" tabindex="0">
       <div class="me-dialog-header">
-        <h3 id="dialog-title">Load Preset</h3>
-        <button type="button" class="me-dialog-close" on:click={onCancelPreset} aria-label="Cancel loading preset">
+        <h3 id="dialog-title">{dialogTitle}</h3>
+        <button type="button" class="me-dialog-close" on:click={onCancelDialog} aria-label="Cancel">
           <X size={18} />
         </button>
       </div>
       <div class="me-dialog-body">
-        <p>Loading this preset will replace your current project and assets. Continue?</p>
+        <p>{dialogMessage}</p>
       </div>
       <div class="me-dialog-footer">
-        <button type="button" class="me-dialog-btn me-secondary" on:click={onCancelPreset}>Cancel</button>
-        <button type="button" class="me-dialog-btn me-danger" on:click={onConfirmPreset}>Load Preset</button>
+        <button type="button" class="me-dialog-btn me-secondary" on:click={onCancelDialog}>Cancel</button>
+        <button type="button" class="me-dialog-btn me-danger" on:click={onConfirmDialog}>{dialogConfirmLabel}</button>
       </div>
     </div>
   </div>

--- a/src/ui/components/motion-editor/content-panel.css
+++ b/src/ui/components/motion-editor/content-panel.css
@@ -1,10 +1,37 @@
 .motion-editor-scope .me-content-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   background: #111214;
   border-right: 1px solid #24262a;
   min-height: 0;
   overflow: hidden;
+}
+
+.motion-editor-scope .me-panel-resize-handle {
+  position: absolute;
+  z-index: 5;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 8px;
+  padding: 0;
+  border: 0;
+  background: linear-gradient(90deg, transparent 3px, #2a2d33 3px, #2a2d33 5px, transparent 5px);
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.motion-editor-scope .me-panel-resize-handle:hover,
+.motion-editor-scope .me-panel-resize-handle:focus-visible {
+  background: linear-gradient(
+    90deg,
+    transparent 3px,
+    var(--accent, #0a84ff) 3px,
+    var(--accent, #0a84ff) 5px,
+    transparent 5px
+  );
+  outline: 0;
 }
 
 .motion-editor-scope .me-panel-header {
@@ -46,6 +73,27 @@
 .motion-editor-scope .me-header-icon-btn:hover {
   background: #202328;
   color: #d8dce2;
+}
+
+.motion-editor-scope .me-import-header-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid #2a2d33;
+  border-radius: 6px;
+  background: #202124;
+  color: #e4e6ea;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.motion-editor-scope .me-import-header-btn:hover {
+  border-color: #3b3f46;
+  background: #292b2f;
 }
 
 .motion-editor-scope .me-panel-content {
@@ -231,9 +279,41 @@
   gap: 8px;
 }
 
+.motion-editor-scope .me-asset-grid.me-list-view {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.motion-editor-scope .me-list-view .me-asset-card {
+  flex-direction: row;
+  align-items: center;
+  min-height: 42px;
+  text-align: left;
+}
+
+.motion-editor-scope .me-list-view .me-asset-thumbnail {
+  flex: 0 0 36px;
+  width: 36px;
+  height: 36px;
+  margin-left: 4px;
+  aspect-ratio: 1;
+  border-radius: 5px;
+}
+
+.motion-editor-scope .me-list-view .me-asset-info {
+  min-width: 0;
+}
+
+.motion-editor-scope .me-asset-card-wrap {
+  position: relative;
+  min-width: 0;
+}
+
 .motion-editor-scope .me-asset-card {
   display: flex;
   flex-direction: column;
+  width: 100%;
   border: 1px solid transparent;
   border-radius: 6px;
   background: #0d0e10;
@@ -241,6 +321,37 @@
   transition: all 0.15s ease;
   overflow: hidden;
   padding: 0;
+}
+
+.motion-editor-scope .me-asset-card-wrap.me-selected .me-asset-card {
+  border-color: var(--accent, #0a84ff);
+  box-shadow: 0 0 0 1px var(--accent, #0a84ff);
+}
+
+.motion-editor-scope .me-list-view .me-asset-card-wrap.me-selected .me-asset-card {
+  border-color: rgba(138, 180, 255, 0.34);
+  background: linear-gradient(90deg, rgba(138, 180, 255, 0.15), rgba(124, 247, 197, 0.07));
+  box-shadow: inset 2px 0 0 var(--accent, #8ab4ff);
+}
+
+.motion-editor-scope .me-folder-delete {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid #2a2d33;
+  border-radius: 6px;
+  color: #a8adb5;
+  background: #17191c;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.motion-editor-scope .me-folder-delete:hover {
+  color: #fff;
+  border-color: #a93434;
+  background: #7f1d1d;
 }
 
 .motion-editor-scope .me-asset-card:hover {
@@ -281,6 +392,7 @@
 
 /* Audio Item */
 .motion-editor-scope .me-audio-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -290,6 +402,25 @@
   background: #0d0e10;
   color: #d8dce2;
   font-size: 13px;
+}
+
+.motion-editor-scope .me-audio-item > span {
+  flex: 1;
+}
+
+.motion-editor-scope .me-layer-row-wrap {
+  position: relative;
+}
+
+.motion-editor-scope .me-layer-row-wrap .me-layer-row {
+  width: 100%;
+}
+
+.motion-editor-scope .me-audio-item.me-selected,
+.motion-editor-scope .me-layer-row-wrap.me-checked .me-layer-row {
+  border-color: rgba(138, 180, 255, 0.34);
+  background: linear-gradient(90deg, rgba(138, 180, 255, 0.15), rgba(124, 247, 197, 0.07));
+  box-shadow: inset 2px 0 0 var(--accent, #8ab4ff);
 }
 
 .motion-editor-scope .me-audio-asset {

--- a/src/ui/components/motion-editor/editor-shell.css
+++ b/src/ui/components/motion-editor/editor-shell.css
@@ -23,11 +23,11 @@
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: 52px 260px 50px minmax(0, 1fr) 300px;
+  grid-template-columns: 52px var(--content-panel-width, 260px) 50px minmax(0, 1fr) 300px;
 }
 
 .motion-editor-scope .me-workbench.me-chat-open {
-  grid-template-columns: 52px 260px 324px minmax(0, 1fr) 300px;
+  grid-template-columns: 52px var(--content-panel-width, 260px) 324px minmax(0, 1fr) 300px;
 }
 
 .motion-editor-scope .me-chat-drawer {

--- a/src/ui/components/motion-editor/editor-theme.css
+++ b/src/ui/components/motion-editor/editor-theme.css
@@ -14,10 +14,10 @@
 }
 
 .motion-editor-scope .me-workbench {
-  grid-template-columns: 60px 260px 50px minmax(0, 1fr) 300px;
+  grid-template-columns: 60px var(--content-panel-width, 260px) 50px minmax(0, 1fr) 300px;
 }
 .motion-editor-scope .me-workbench.me-chat-open {
-  grid-template-columns: 60px 260px 324px minmax(0, 1fr) 300px;
+  grid-template-columns: 60px var(--content-panel-width, 260px) 324px minmax(0, 1fr) 300px;
 }
 
 .motion-editor-scope .me-nav-rail {
@@ -392,13 +392,13 @@
 /* Final matte refinement and strict rail/panel containment. */
 .motion-editor-scope .me-workbench,
 .motion-editor-scope .me-workbench.me-chat-open {
-  grid-template-columns: 60px 260px 50px minmax(0, 1fr) 300px;
+  grid-template-columns: 60px var(--content-panel-width, 260px) 50px minmax(0, 1fr) 300px;
   overflow: hidden;
   isolation: isolate;
   background: #0e0e10;
 }
 .motion-editor-scope .me-workbench.me-chat-open {
-  grid-template-columns: 60px 260px 324px minmax(0, 1fr) 300px;
+  grid-template-columns: 60px var(--content-panel-width, 260px) 324px minmax(0, 1fr) 300px;
 }
 .motion-editor-scope .me-nav-rail {
   grid-column: 1;
@@ -417,7 +417,7 @@
   box-sizing: border-box;
   width: 100%;
   min-width: 0;
-  max-width: 260px;
+  max-width: none;
   contain: paint;
   background: #151517;
   border-right: 1px solid var(--hairline);
@@ -794,7 +794,7 @@
 }
 
 .motion-editor-scope .me-workbench.me-chat-open {
-  grid-template-columns: 60px 260px 360px minmax(0, 1fr) 300px;
+  grid-template-columns: 60px var(--content-panel-width, 260px) 360px minmax(0, 1fr) 300px;
 }
 
 /* Quiet workspace grid, refined property controls, and logo-gradient interactions. */

--- a/tests/ui/motion-editor-components.test.ts
+++ b/tests/ui/motion-editor-components.test.ts
@@ -116,9 +116,12 @@ describe('motion editor leaf components', () => {
         deleteToast: 'Deleted title',
         keyframeNotice: 'Keyframe created',
         showConfirmDialog: true,
+        dialogTitle: 'Load Preset',
+        dialogMessage: 'Replace the project?',
+        dialogConfirmLabel: 'Load Preset',
         onUndoDelete,
-        onCancelPreset,
-        onConfirmPreset,
+        onCancelDialog: onCancelPreset,
+        onConfirmDialog: onConfirmPreset,
       },
     });
 
@@ -126,11 +129,7 @@ describe('motion editor leaf components', () => {
       Array.from(host.querySelectorAll('button')).find((button) => button.textContent === 'Undo') ??
         null
     );
-    click(
-      Array.from(host.querySelectorAll('button')).find(
-        (button) => button.textContent === 'Cancel'
-      ) ?? null
-    );
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     click(
       Array.from(host.querySelectorAll('button')).find(
         (button) => button.textContent === 'Load Preset'
@@ -146,6 +145,127 @@ describe('motion editor leaf components', () => {
 });
 
 describe('MotionEditor integration', () => {
+  it('deletes an imported asset from the asset sidebar', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    vi.stubGlobal(
+      'Image',
+      class {
+        decode = () => Promise.resolve();
+      }
+    );
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 2s background #000000 }
+import "./logo.png" as logo
+import "./other.png" as other
+image product { source logo center }
+animate product { from { opacity 0 } to { opacity 1 } duration 1s }
+clip logo { start 0s duration 2s }
+text title { value "Title" center }
+text subtitle { value "Subtitle" center }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+
+    click(host.querySelector('[aria-label="Show list view"]'));
+    await tick();
+    expect(host.querySelector('.me-asset-grid')?.classList.contains('me-list-view')).toBe(true);
+    click(host.querySelector('[aria-label="Show grid view"]'));
+    await tick();
+    expect(host.querySelector('.me-asset-grid')?.classList.contains('me-list-view')).toBe(false);
+
+    click(host.querySelector('[aria-label="Select and preview logo"]'));
+    await tick();
+    expect(host.querySelector('.me-asset-card-wrap')?.classList.contains('me-selected')).toBe(true);
+    expect(host.querySelector('[aria-label="Delete selected asset"]')).not.toBeNull();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await tick();
+    expect(host.querySelector('[aria-label="Delete selected asset"]')).toBeNull();
+
+    click(host.querySelector('[aria-label="Select and preview logo"]'));
+    await tick();
+    click(host.querySelector('[aria-label="Text"]'));
+    await tick();
+    click(host.querySelector('[aria-label="Media / Assets"]'));
+    await tick();
+    expect(host.querySelector('[aria-label="Delete selected asset"]')).toBeNull();
+
+    click(host.querySelector('[aria-label="Select and preview logo"]'));
+    await tick();
+    host
+      .querySelector('[aria-label="Select and preview other"]')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, ctrlKey: true }));
+    await tick();
+    expect(host.querySelectorAll('.me-asset-card-wrap.me-selected')).toHaveLength(2);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    click(host.querySelector('[aria-label="Select and preview logo"]'));
+    host
+      .querySelector('[aria-label="Select and preview other"]')
+      ?.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, shiftKey: true }));
+    await tick();
+    expect(host.querySelectorAll('.me-asset-card-wrap.me-selected')).toHaveLength(2);
+
+    click(host.querySelector('[aria-label="Delete selected assets"]'));
+    await tick();
+
+    expect(host.querySelector('.me-dialog-body')?.textContent).toContain(
+      'Delete 2 selected assets and their timeline items?'
+    );
+    click(
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Delete'
+      ) ?? null
+    );
+    await tick();
+    expect(host.querySelector('[aria-label="Select and preview logo"]')).toBeNull();
+    expect(host.querySelector('[aria-label="Select and preview other"]')).toBeNull();
+
+    click(host.querySelector('[aria-label="Text"]'));
+    await tick();
+    click(host.querySelector('[aria-label="Select title"]'));
+    host
+      .querySelector('[aria-label="Select subtitle"]')
+      ?.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, shiftKey: true }));
+    await tick();
+    expect(host.querySelectorAll('.me-layer-row-wrap.me-checked')).toHaveLength(2);
+    click(host.querySelector('[aria-label="Delete selected text layers"]'));
+    await tick();
+    expect(host.querySelector('.me-dialog-body')?.textContent).toContain(
+      'Delete 2 selected text layers?'
+    );
+    click(
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Delete'
+      ) ?? null
+    );
+    await tick();
+
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const source = host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value ?? '';
+    expect(source).not.toContain('import ');
+    expect(source).not.toContain('image product');
+    expect(source).not.toContain('animate product');
+    expect(source).not.toContain('clip logo');
+    expect(source).not.toContain('text title');
+    expect(source).not.toContain('text subtitle');
+
+    await unmount(instance);
+  });
+
   it('mounts every major region and keeps nested panel styles isolated', async () => {
     class ResizeObserverStub {
       observe(): void {}
@@ -177,6 +297,18 @@ describe('MotionEditor integration', () => {
     expect(host.querySelector('.me-properties-panel')).not.toBeNull();
     expect(host.querySelector('.me-timeline-panel')).not.toBeNull();
     expect(host.querySelector('.me-source-toggle')).not.toBeNull();
+
+    host
+      .querySelector('[aria-label="Resize asset panel"]')
+      ?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 260 }));
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 320 }));
+    window.dispatchEvent(new MouseEvent('pointerup'));
+    await tick();
+    expect(
+      host
+        .querySelector<HTMLElement>('.me-workbench')
+        ?.style.getPropertyValue('--content-panel-width')
+    ).toBe('320px');
 
     click(host.querySelector('[aria-label="Settings"]'));
     await tick();


### PR DESCRIPTION
• ## Summary

  - Added asset selection, multi-selection, and range-selection shortcuts.
  - Added grid and list views for imported media.
  - Added batch deletion with Motionly-styled confirmation dialogs.
  - Added consistent selection highlighting for assets, audio, and text.
  - Added a resizable content panel and improved media import controls.
  - Removed duplicate audio content from the Assets panel.
  - Added Escape-based selection and dialog cancellation.

  ## Testing

  - npm test -- --run tests/ui/motion-editor-components.test.ts
  - npm run type-check
  - npm run build
  
  ## Checklist

  - [x] I ran npm test.
  - [x] I kept the change scoped and readable.
  - [ ] I updated docs for syntax, preset, export, or public behavior changes.
  - [x] I did not mutate imported assets or add hidden renderer state.