### PR TITLE
feat(assets): save dragged/uploaded assets into the project assets folder (#53)

### DIFF
--- a/bin/motionly.js
+++ b/bin/motionly.js
@@ -308,6 +308,17 @@ async function readRequestBody(request, maximum = 5_000_000) {
   return source;
 }
 
+async function readRequestBuffer(request, maximum = 200_000_000) {
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of request) {
+    total += chunk.length;
+    if (total > maximum) throw new Error('TOO_LARGE');
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
 function safeFile(rootPath, pathname) {
   const filePath = normalize(join(rootPath, pathname));
   return filePath === rootPath || filePath.startsWith(`${rootPath}${sep}`) ? filePath : null;
@@ -371,7 +382,7 @@ async function serveEditor(argv, projectFolder = null) {
         return;
       }
 
-      if (pathname.startsWith('/assets/')) {
+      if (pathname.startsWith('/assets/') && (request.method === 'GET' || request.method === 'HEAD')) {
         const bundledAsset = safeFile(dist, pathname.slice(1));
         if (bundledAsset && (await exists(bundledAsset))) {
           await serveFile(response, bundledAsset, request.method);
@@ -381,8 +392,17 @@ async function serveEditor(argv, projectFolder = null) {
 
       if (assetsRoot && pathname.startsWith('/assets/')) {
         const filePath = safeFile(assetsRoot, pathname.slice('/assets/'.length));
-        if (!filePath) {
+        if (!filePath || filePath === assetsRoot) {
           response.writeHead(403).end('Forbidden');
+          return;
+        }
+        if (request.method === 'PUT') {
+          // Save an uploaded/dragged asset into the project's on-disk assets folder
+          // so it can be reused, edited, or deleted like any other project media.
+          const data = await readRequestBuffer(request);
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, data);
+          response.writeHead(204, { 'X-Motionly-Asset': basename(filePath) }).end();
           return;
         }
         await serveFile(response, filePath, request.method);

--- a/src/ui/MotionlyApp.svelte
+++ b/src/ui/MotionlyApp.svelte
@@ -293,7 +293,7 @@ animate title {
   </div>
 
   <!-- Editor -->
-  <MotionEditor bind:this={editor} bind:code={motionCode} onSave={handleSave} />
+  <MotionEditor bind:this={editor} bind:code={motionCode} onSave={handleSave} {serverBacked} />
 </div>
 
 <style>

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -93,6 +93,7 @@
 
   export let code = '';
   export let onSave: () => void | Promise<void> = () => undefined;
+  export let serverBacked = false;
   let canvas: HTMLCanvasElement;
   let stage: HTMLDivElement;
   let renderer: CanvasRenderer | null = null;
@@ -170,6 +171,7 @@
   let previewAsset: AssetPreview | null = null;
   let videoRenderId = 0;
   let isDraggingUpload = false;
+  let stageDropActive = false;
   let draggingAsset: Asset | null = null;
   let draggingAudio = false;
   let draggingTransition: 'crossfade' | null = null;
@@ -1453,6 +1455,33 @@
     await importAssetFiles(event.dataTransfer?.files);
   }
 
+  // Dropping OS files directly onto the preview stage saves them into the asset
+  // folder (Media panel), where they can be viewed, reused, or deleted.
+  function handleStageFileDragOver(event: DragEvent) {
+    if (!event.dataTransfer?.types.includes('Files')) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    stageDropActive = true;
+  }
+
+  function handleStageFileDragLeave(event: DragEvent) {
+    if (!(event.currentTarget as HTMLElement).contains(event.relatedTarget as Node | null)) {
+      stageDropActive = false;
+    }
+  }
+
+  async function handleStageFileDrop(event: DragEvent) {
+    if (!event.dataTransfer?.types.includes('Files')) return;
+    event.preventDefault();
+    stageDropActive = false;
+    const added = await importAssetFiles(event.dataTransfer.files);
+    if (added.length) {
+      // Reveal the freshly imported media so the drop has a visible result.
+      activeNavTab = 'media';
+      mediaSubTab = 'assets';
+    }
+  }
+
   function handleAssetFileDrag(event: DragEvent) {
     if (event.dataTransfer?.types.includes('Files')) isDraggingUpload = true;
   }
@@ -1463,12 +1492,37 @@
     }
   }
 
-  async function importAssetFiles(fileList: FileList | null | undefined) {
-    if (!ast) return;
+  /**
+   * Persist an uploaded/dragged file so the editor can reference it.
+   *
+   * In a server-backed project (npx init → CLI `dev`), the file is written into
+   * the project's on-disk `assets/` folder via the local editor server and
+   * referenced by relative path, so it becomes real, reusable project media.
+   * In the browser-only editor (no project server) there is nowhere to write, so
+   * the file is embedded in the `.motion` source as a tagged data URL instead.
+   */
+  async function persistAssetFile(file: File): Promise<string> {
+    if (serverBacked) {
+      const response = await fetch(`/assets/${encodeURIComponent(file.name)}`, {
+        method: 'PUT',
+        headers: { 'content-type': file.type || 'application/octet-stream' },
+        body: file,
+      });
+      if (!response.ok) {
+        throw new Error(`Could not save ${file.name} to the project assets folder (${response.status}).`);
+      }
+      return `./assets/${file.name}`;
+    }
+    return tagEmbeddedAssetPath(await readFileDataUrl(file), file.name);
+  }
+
+  async function importAssetFiles(fileList: FileList | null | undefined): Promise<string[]> {
+    if (!ast) return [];
     const program = ast;
     assetError = '';
     const files = Array.from(fileList ?? []);
-    if (!files.length) return;
+    if (!files.length) return [];
+    const addedNames: string[] = [];
     for (const file of files) {
       const lowerName = file.name.toLowerCase();
       const isImage = file.type.startsWith('image/') || lowerName.endsWith('.svg');
@@ -1481,13 +1535,6 @@
       const maximumSize = isVideo ? 100_000_000 : isLottie ? 50_000_000 : 10_000_000;
       if (file.size > maximumSize) {
         assetError = `${file.name} is larger than ${isVideo ? '100' : isLottie ? '50' : '10'} MB.`;
-        continue;
-      }
-      let path = '';
-      try {
-        path = tagEmbeddedAssetPath(await readFileDataUrl(file), file.name);
-      } catch (cause) {
-        assetError = cause instanceof Error ? cause.message : `Could not read ${file.name}.`;
         continue;
       }
       const matchingImports = program.body.filter(
@@ -1519,8 +1566,23 @@
           assetError = `Kept the current ${file.name}.`;
           continue;
         }
-        for (const node of matchingImports) node.path = path;
+        // Persist only after the replace decision so declining never overwrites disk media.
+        let replacedPath = '';
+        try {
+          replacedPath = await persistAssetFile(file);
+        } catch (cause) {
+          assetError = cause instanceof Error ? cause.message : `Could not save ${file.name}.`;
+          continue;
+        }
+        for (const node of matchingImports) node.path = replacedPath;
         assetError = `Matched ${file.name} to its existing import by filename.`;
+        continue;
+      }
+      let path = '';
+      try {
+        path = await persistAssetFile(file);
+      } catch (cause) {
+        assetError = cause instanceof Error ? cause.message : `Could not save ${file.name}.`;
         continue;
       }
       const used = new Set(program.body.flatMap((node) => node.type === 'Import' ? [node.name] : node.type === 'Element' ? [node.name] : []));
@@ -1529,8 +1591,10 @@
       let suffix = 2;
       while (used.has(name)) name = `${base}_${suffix++}`;
       program.body.push({ type: 'Import', path, name });
+      addedNames.push(name);
     }
     code = serializeProgram(program);
+    return addedNames;
   }
 
   async function readMediaIdentity(file: File, isVideo: boolean) {
@@ -2935,12 +2999,16 @@
       {previewAsset}
       {parseError}
       {exportError}
+      fileDropActive={stageDropActive}
       onFit={fitPreview}
       onToggleFullscreen={toggleFullscreen}
       onPointerDown={handleCanvasPointerDown}
       onPointerMove={handleCanvasPointerMove}
       onPointerUp={handleCanvasPointerUp}
       onClearAssetPreview={clearAssetPreview}
+      onFileDragOver={handleStageFileDragOver}
+      onFileDragLeave={handleStageFileDragLeave}
+      onFileDrop={handleStageFileDrop}
     />
 
     <PropertiesInspector

--- a/src/ui/components/motion-editor/PreviewStage.svelte
+++ b/src/ui/components/motion-editor/PreviewStage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './preview-stage.css';
-  import { Maximize2, X } from 'lucide-svelte';
+  import { Maximize2, Upload, X } from 'lucide-svelte';
   import type { SnapGuides } from '../../canvas-geometry';
   import type { AssetPreview } from './types';
 
@@ -16,12 +16,16 @@
   export let previewAsset: AssetPreview | null;
   export let parseError: string | null;
   export let exportError: string;
+  export let fileDropActive = false;
   export let onFit: () => void;
   export let onToggleFullscreen: () => void;
   export let onPointerDown: (event: PointerEvent) => void;
   export let onPointerMove: (event: PointerEvent) => void;
   export let onPointerUp: (event: PointerEvent) => void;
   export let onClearAssetPreview: () => void;
+  export let onFileDragOver: (event: DragEvent) => void = () => undefined;
+  export let onFileDragLeave: (event: DragEvent) => void = () => undefined;
+  export let onFileDrop: (event: DragEvent) => void = () => undefined;
 </script>
 
 <main class="me-preview-container">
@@ -35,7 +39,16 @@
       </button>
     </div>
   </div>
-  <div bind:this={stage} class="me-stage">
+  <div
+    bind:this={stage}
+    class="me-stage"
+    class:me-stage-drop-active={fileDropActive}
+    role="region"
+    aria-label="Preview canvas. Drop media files here to add them to your assets."
+    on:dragover={onFileDragOver}
+    on:dragleave={onFileDragLeave}
+    on:drop={onFileDrop}
+  >
     {#if !assetsReady}<div class="me-stage-status" role="status"><span></span> Preparing project media…</div>{/if}
     <div class="me-canvas-shell" style={canvasStyle}>
       <canvas
@@ -56,6 +69,12 @@
         <span class="me-snap-guide me-snap-guide-h" style={`top: ${(snapGuides.horizontal / canvasHeight) * 100}%`}></span>
       {/if}
     </div>
+    {#if fileDropActive}
+      <div class="me-stage-drop-hint" role="status">
+        <Upload size={22} />
+        <span>Drop to add to your assets</span>
+      </div>
+    {/if}
     {#if previewAsset}
       <div class="me-asset-preview-overlay">
         {#if previewAsset.type === 'video'}

--- a/src/ui/components/motion-editor/preview-stage.css
+++ b/src/ui/components/motion-editor/preview-stage.css
@@ -76,6 +76,33 @@
   position: relative;
 }
 
+.motion-editor-scope .me-stage.me-stage-drop-active::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  z-index: 90;
+  border: 2px dashed rgba(10, 132, 255, 0.7);
+  border-radius: 10px;
+  background: rgba(10, 132, 255, 0.08);
+  pointer-events: none;
+}
+
+.motion-editor-scope .me-stage-drop-hint {
+  position: absolute;
+  inset: 0;
+  z-index: 91;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: #cfe3ff;
+  font-size: 14px;
+  font-weight: 550;
+  pointer-events: none;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.6);
+}
+
 .motion-editor-scope .me-property-align-actions {
   display: grid;
   grid-template-columns: repeat(3, 1fr) 1px repeat(3, 1fr);

--- a/tests/cli/local-workflow.test.ts
+++ b/tests/cli/local-workflow.test.ts
@@ -140,6 +140,29 @@ describe('local CLI workflow', () => {
       const asset = await fetch(`http://127.0.0.1:${port}/assets/logo.svg`, { method: 'HEAD' });
       expect(asset.headers.get('content-length')).toBe('11');
 
+      // Uploading an asset writes it into the project's on-disk assets folder
+      // and serves it back (issue #53: save dragged assets into the asset folder).
+      const uploaded = await fetch(`http://127.0.0.1:${port}/assets/dropped.svg`, {
+        method: 'PUT',
+        headers: { 'content-type': 'image/svg+xml' },
+        body: '<svg id="dropped"></svg>',
+      });
+      expect(uploaded.status).toBe(204);
+      expect(await readFile(join(workspace, 'demo', 'assets', 'dropped.svg'), 'utf8')).toContain(
+        'id="dropped"'
+      );
+      const servedUpload = await fetch(`http://127.0.0.1:${port}/assets/dropped.svg`);
+      expect(servedUpload.status).toBe(200);
+      expect(await servedUpload.text()).toContain('id="dropped"');
+
+      // Path traversal outside the assets folder is rejected.
+      const traversal = await fetch(`http://127.0.0.1:${port}/assets/..%2f..%2fhacked.svg`, {
+        method: 'PUT',
+        headers: { 'content-type': 'image/svg+xml' },
+        body: '<svg></svg>',
+      });
+      expect(traversal.status).toBe(403);
+
       const updated = source.replace('value "demo"', 'value "Saved"');
       const saved = await fetch(`http://127.0.0.1:${port}/api/motion-project`, {
         method: 'PUT',


### PR DESCRIPTION
## Summary

Fixes #53. When working in a scaffolded project (`npx @coppsary/motionly init`),
media that a user uploads or drags into the editor is now written into the
project's on-disk `assets/` folder and referenced by path
(`import "./assets/<name>"`), instead of being embedded as a data URL. The
asset becomes real project media the user can view, reuse, edit, or delete.

The preview canvas is also now a drop target, so files dragged directly onto
the editor (not just the media panel) are saved too.

## Behavior

- **Server-backed project** (CLI `init`/`dev`): uploads are `PUT` to the local
editor server, which writes them into `assets/` on disk. `project.motion`
references them by relative path.
- **Browser-only editor** (no project server): unchanged — assets are still
embedded as data URLs, since there's nowhere on disk to write.

## Changes

- **bin/motionly.js** — add `PUT /assets/<name>` endpoint (binary-safe write,
path-traversal guarded, 200 MB cap); restrict the bundled-dist `/assets/`
fast-path to GET/HEAD so PUTs reach the project folder.
- **MotionEditor.svelte** — new `serverBacked` prop and `persistAssetFile()`:
uploads to disk when server-backed, else embeds. Reordered `importAssetFiles`
so the disk write happens **after** the "replace anyway?" confirmation, so
declining never clobbers an existing file.
- **MotionlyApp.svelte** — pass the `serverBacked` flag into the editor.
- **PreviewStage.svelte / preview-stage.css** — accept OS file drops on the
canvas with a "Drop to add to your assets" overlay.

## Testing

- Extended the real-server CLI test: upload → `204` + lands on disk, served
back via GET, and traversal is rejected (`403`).
- `npm run test:run` — 192/192 pass. `svelte-check` — 0 errors/0 warnings.
- Manual end-to-end against a fresh `npm run build`: `init` → `dev` → upload →
file appears in `assets/` and is referenced by path in `project.motion`.