### PR TITLE
fix(timeline): scale clip bars to real duration and auto-extend on drag (#50)

### DIFF
--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -91,6 +91,17 @@
     'fill',
   ];
 
+  // Timeline layout: clips are drawn at a fixed pixels-per-second scale (× zoom)
+  // so a clip's on-screen length reflects its real duration. At rest the ruler
+  // spans the content end (or the visible panel, whichever is longer) with no
+  // trailing padding. While a clip is being dragged/stretched toward the end,
+  // the ruler grows to follow so there is room to extend; committing past the
+  // old end grows the project. Fixed px/s means existing clips never shift when
+  // the ruler grows.
+  const TIMELINE_LABEL_WIDTH = 220;
+  const TIMELINE_PIXELS_PER_SECOND = 100;
+  const TIMELINE_MIN_LANE_WIDTH = 160;
+
   export let code = '';
   export let onSave: () => void | Promise<void> = () => undefined;
   export let serverBacked = false;
@@ -187,6 +198,10 @@
   let editorHistory = createEditorHistory(code);
   let timelineScroll: HTMLDivElement;
   let timelineZoom = 1;
+  let timelineViewportWidth = 0;
+  // While a clip/element is being dragged or stretched toward the end this holds
+  // the current far edge (seconds) so the ruler can grow to follow; 0 when idle.
+  let timelineDragReach = 0;
   let snapEnabled = true;
   let timelineSnapGuide: number | null = null;
   let historyGestureBase: string | null = null;
@@ -208,6 +223,16 @@
     const observer = new ResizeObserver(fitPreview);
     if (stage) observer.observe(stage);
     requestAnimationFrame(fitPreview);
+
+    // Track the timeline viewport width so the lane scale can fit long projects
+    // to the visible area while keeping short projects compact.
+    const measureTimeline = () => {
+      if (timelineScroll) timelineViewportWidth = timelineScroll.clientWidth;
+    };
+    const timelineObserver = new ResizeObserver(measureTimeline);
+    if (timelineScroll) timelineObserver.observe(timelineScroll);
+    measureTimeline();
+    requestAnimationFrame(measureTimeline);
     
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target instanceof Element ? e.target : null;
@@ -274,6 +299,7 @@
     
     return () => {
       observer.disconnect();
+      timelineObserver.disconnect();
       disposeAssets(assets);
       audioLoadId += 1;
       audioWaveformLoadId += 1;
@@ -449,7 +475,7 @@
           boundary.type !== null
       ) ?? null
     : null;
-  $: timelineTicks = Array.from({ length: 7 }, (_, index) => (totalDuration * index) / 6);
+  $: timelineTicks = Array.from({ length: 7 }, (_, index) => (timelineVisibleDuration * index) / 6);
   $: displayFrame = Math.round(currentTime * (scene?.canvas.fps ?? 60));
   $: assistantAssets = mergeAssets(scene?.imports ?? [], embeddedAssets);
   $: canvasWidth = scene?.canvas.width ?? 1920;
@@ -462,7 +488,40 @@
     elementCount: sourceElements.length,
   };
   $: canvasStyle = `width: ${Math.round(canvasWidth * zoom)}px; aspect-ratio: ${canvasWidth} / ${canvasHeight};`;
-  $: timelineContentWidth = Math.max(820, 220 + totalDuration * 100 * timelineZoom);
+  // The last clipbar end (content end). The playhead is clamped here; the ruler
+  // extends a fixed tail past it so clips can be dragged/extended into the gap.
+  $: timelineContentEnd = (() => {
+    const ends = [
+      ...(scene?.clips ?? []).map((clip) => clip.start + clip.duration),
+      ...(scene?.elements ?? []).map((element) => timelineRange(element.id).end),
+    ].filter((value) => Number.isFinite(value));
+    return ends.length ? Math.max(0, ...ends) : Math.max(0, totalDuration);
+  })();
+  // Fixed pixels-per-second scale (× zoom): a clip is drawn at duration × scale,
+  // so short clips look short. The ruler/drag extent is the content end plus a
+  // fixed tail so there is always room to drag or stretch a clip; committing a
+  // clip past the current end grows the project (see extendProjectDuration).
+  // All clip/tick/playhead positions are percentages of timelineVisibleDuration.
+  $: timelinePixelsPerSecond = TIMELINE_PIXELS_PER_SECOND * timelineZoom;
+  $: timelineAvailableLaneWidth = Math.max(
+    TIMELINE_MIN_LANE_WIDTH,
+    timelineViewportWidth - TIMELINE_LABEL_WIDTH
+  );
+  // Seconds that fill the visible panel at the current scale.
+  $: timelineFillPanelDuration =
+    timelinePixelsPerSecond > 0 ? timelineAvailableLaneWidth / timelinePixelsPerSecond : 0;
+  // At rest: content end, or the panel width if the content is shorter (so a
+  // short clip looks short inside a filled ruler, with no trailing padding).
+  // While dragging toward the end: grow to keep half a screen of room ahead of
+  // the drag so it can be extended; existing clips keep their pixel position
+  // because the scale is fixed.
+  $: timelineVisibleDuration = Math.max(
+    timelineContentEnd,
+    timelineFillPanelDuration,
+    timelineDragReach > 0 ? timelineDragReach + timelineFillPanelDuration * 0.5 : 0
+  );
+  $: timelineLaneWidth = timelineVisibleDuration * timelinePixelsPerSecond;
+  $: timelineContentWidth = TIMELINE_LABEL_WIDTH + timelineLaneWidth;
 
   function parseAndRender() {
     try {
@@ -682,7 +741,8 @@
   }
 
   function quantizeTimelineTime(time: number): number {
-    return quantizeFrameTime(time, totalDuration, scene?.canvas.fps ?? 60);
+    // Clamp the playhead to the last clipbar end, not the padded ruler tail.
+    return quantizeFrameTime(time, timelineContentEnd, scene?.canvas.fps ?? 60);
   }
 
   function seek(event: Event) {
@@ -807,9 +867,12 @@
     return { start: Math.max(0, start), end: Math.min(totalDuration, end) };
   }
 
-  function timelinePercent(time: number): number {
-    return totalDuration > 0 ? Math.max(0, Math.min(100, (time / totalDuration) * 100)) : 0;
-  }
+  // Reactive so clip/tick/playhead positions recompute when the visible
+  // duration changes (e.g. on zoom), not just when the project duration does.
+  $: timelinePercent = (time: number): number =>
+    timelineVisibleDuration > 0
+      ? Math.max(0, Math.min(100, (time / timelineVisibleDuration) * 100))
+      : 0;
 
   async function handleAudioSelected(event: Event) {
     const input = event.currentTarget as HTMLInputElement;
@@ -1068,16 +1131,24 @@
   function trimElement(event: PointerEvent, id: string, edge: 'start' | 'end') {
     event.preventDefault();
     event.stopPropagation();
-    const lane = (event.currentTarget as HTMLElement).closest('.me-track-lane');
-    if (!lane) return;
+    const laneEl = (event.currentTarget as HTMLElement).closest<HTMLElement>('.me-track-lane[data-track]');
+    if (!laneEl) return;
+    const trackId = laneEl.dataset['track'] ?? '';
     beginHistoryGesture();
-    const rect = lane.getBoundingClientRect();
     const update = (pointer: PointerEvent) => {
-      const raw = ((pointer.clientX - rect.left) / rect.width) * totalDuration;
-      setClipBoundary(id, edge, snapTimelineTime(raw, rect.width, id));
+      // Fetch the lane live: the ruler (and this element) can grow/re-render
+      // mid-trim, so a rect captured up front would go stale.
+      const rect = timelineLaneRect(trackId) ?? laneEl.getBoundingClientRect();
+      const raw = ((pointer.clientX - rect.left) / rect.width) * timelineVisibleDuration;
+      if (edge === 'end') {
+        timelineDragReach = raw;
+        followTimelineDrag(raw);
+      }
+      setClipBoundary(id, edge, snapTimelineTime(raw, rect.width, id, raw + timelineFillPanelDuration));
     };
     const stop = () => {
       timelineSnapGuide = null;
+      timelineDragReach = 0;
       endHistoryGesture();
       window.removeEventListener('pointermove', update);
       window.removeEventListener('pointerup', stop);
@@ -1097,6 +1168,7 @@
     const start = edge === 'start' ? Math.min(time, range.end - minimum) : range.start;
     const end = edge === 'end' ? Math.max(time, range.start + minimum) : range.end;
     element.properties = elementWindowProperties(element.properties, start, end, minimum);
+    extendProjectDuration(end);
     code = serializeProgram(ast);
   }
 
@@ -2114,12 +2186,29 @@
       : laneTrackAtPoint(pointer.clientX, pointer.clientY) ?? clipDrag.originTrackId;
     const rect = timelineLaneRect(targetTrackId);
     if (!rect) return;
-    const pointerTime = ((pointer.clientX - rect.left) / rect.width) * totalDuration;
-    const rawStart = Math.min(
-      totalDuration,
-      Math.max(0, snapTimelineTime(pointerTime - clipDrag.grabOffset, rect.width, clipDrag.id))
+    const pointerTime = ((pointer.clientX - rect.left) / rect.width) * timelineVisibleDuration;
+    // Follow the pointer; the ruler grows via timelineDragReach so there is
+    // always room to keep extending. The project only grows on commit.
+    const rawStart = Math.max(
+      0,
+      snapTimelineTime(
+        pointerTime - clipDrag.grabOffset,
+        rect.width,
+        clipDrag.id,
+        timelineVisibleDuration
+      )
     );
     clipDrag = { ...clipDrag, ghostStart: rawStart, ghostTrackId: targetTrackId, valid: true };
+    timelineDragReach = rawStart + clipDrag.duration;
+    followTimelineDrag(timelineDragReach);
+  }
+
+  /** Keep the dragged/stretched end in view as the ruler grows behind it. */
+  function followTimelineDrag(reachSeconds: number) {
+    if (!timelineScroll) return;
+    const endPx = TIMELINE_LABEL_WIDTH + Math.max(0, reachSeconds) * timelinePixelsPerSecond;
+    const viewRight = timelineScroll.scrollLeft + timelineScroll.clientWidth;
+    if (endPx > viewRight - 48) timelineScroll.scrollLeft = endPx - timelineScroll.clientWidth + 48;
   }
 
   function moveTimelineClip(event: PointerEvent, clip: Clip) {
@@ -2129,7 +2218,7 @@
     selectElement(clip.id, false);
     const rect = timelineLaneRect(String(clip.track));
     if (!rect) return;
-    const grabTime = ((event.clientX - rect.left) / rect.width) * totalDuration;
+    const grabTime = ((event.clientX - rect.left) / rect.width) * timelineVisibleDuration;
     clipDrag = {
       id: clip.id,
       kind: 'clip',
@@ -2161,10 +2250,24 @@
     window.addEventListener('pointercancel', stop);
   }
 
+  /** Grow the canvas duration so a moved clip/element that ends past the current
+   *  project end still fits inside the rendered timeline. */
+  function extendProjectDuration(minDuration: number) {
+    if (!ast || !Number.isFinite(minDuration) || minDuration <= totalDuration) return;
+    const canvasNode = ast.body.find((candidate) => candidate.type === 'Canvas');
+    if (canvasNode) {
+      canvasNode.properties = {
+        ...canvasNode.properties,
+        duration: `${minDuration.toFixed(3)}s`,
+      };
+    }
+  }
+
   function commitClipDrag() {
     const drag = clipDrag;
     clipDrag = null;
     timelineSnapGuide = null;
+    timelineDragReach = 0;
     if (!drag || !scene || !drag.moved || !drag.valid) return;
     if (drag.kind === 'audio') {
       const node = ast?.body.find((candidate): candidate is AudioNode => candidate.type === 'Audio');
@@ -2183,9 +2286,12 @@
         drag.id,
         targetTrack,
         drag.ghostStart,
-        totalDuration
+        timelineVisibleDuration
       );
-      if (next) writeClipLayout(next);
+      if (next) {
+        extendProjectDuration(drag.ghostStart + drag.duration);
+        writeClipLayout(next);
+      }
       endHistoryGesture();
       return;
     }
@@ -2217,6 +2323,7 @@
       ...node.properties,
       track: targetTrack.id,
     };
+    extendProjectDuration(end);
     code = serializeProgram(ast);
     endHistoryGesture();
   }
@@ -2240,7 +2347,7 @@
       String(node.properties['track'] ?? scene.tracks.find((track) => track.role === 'overlay')?.id ?? defaultMainTrack);
     const rect = originLane?.getBoundingClientRect() ?? timelineLaneRect(originTrackId);
     if (!rect) return;
-    const grabTime = ((event.clientX - rect.left) / rect.width) * totalDuration;
+    const grabTime = ((event.clientX - rect.left) / rect.width) * timelineVisibleDuration;
     clipDrag = {
       id: element.id,
       kind: 'element',
@@ -2279,7 +2386,7 @@
     const lane = (event.currentTarget as HTMLElement).closest<HTMLElement>('.me-track-lane[data-track]');
     const rect = lane?.getBoundingClientRect();
     if (!rect) return;
-    const grabTime = ((event.clientX - rect.left) / rect.width) * totalDuration;
+    const grabTime = ((event.clientX - rect.left) / rect.width) * timelineVisibleDuration;
     clipDrag = {
       id: '__audio__',
       kind: 'audio',
@@ -2311,14 +2418,15 @@
     event.preventDefault();
     event.stopPropagation();
     selectElement(clip.id, false);
-    const lane = (event.currentTarget as HTMLElement).closest<HTMLElement>('.me-track-lane');
-    if (!lane) return;
+    const laneEl = (event.currentTarget as HTMLElement).closest<HTMLElement>('.me-track-lane[data-track]');
+    if (!laneEl) return;
+    const trackId = laneEl.dataset['track'] ?? '';
     beginHistoryGesture();
-    const rect = lane.getBoundingClientRect();
     const minimum = 1 / (scene?.canvas.fps ?? 60);
     const move = (pointer: PointerEvent) => {
-      const raw = ((pointer.clientX - rect.left) / rect.width) * totalDuration;
-      const time = snapTimelineTime(raw, rect.width, clip.id);
+      const rect = timelineLaneRect(trackId) ?? laneEl.getBoundingClientRect();
+      const raw = ((pointer.clientX - rect.left) / rect.width) * timelineVisibleDuration;
+      const time = snapTimelineTime(raw, rect.width, clip.id, raw + timelineFillPanelDuration);
       if (!scene) return;
       const next = trimClipOnTrack(
         scene.clips,
@@ -2327,10 +2435,20 @@
         time,
         minimum
       );
+      const trimmed = next.find((candidate) => candidate.id === clip.id);
+      if (trimmed) {
+        const trimmedEnd = trimmed.start + trimmed.duration;
+        extendProjectDuration(trimmedEnd);
+        if (edge === 'end') {
+          timelineDragReach = trimmedEnd;
+          followTimelineDrag(trimmedEnd);
+        }
+      }
       writeClipLayout(next);
     };
     const stop = () => {
       timelineSnapGuide = null;
+      timelineDragReach = 0;
       endHistoryGesture();
       window.removeEventListener('pointermove', move);
       window.removeEventListener('pointerup', stop);
@@ -2389,12 +2507,12 @@
   }
 
   function timelineTimeAt(clientX: number, rect: DOMRect): number {
-    const raw = ((clientX - rect.left) / rect.width) * totalDuration;
+    const raw = ((clientX - rect.left) / rect.width) * timelineVisibleDuration;
     return snapTimelineTime(raw, rect.width);
   }
 
-  function snapTimelineTime(raw: number, width: number, excludeClipId = ''): number {
-    const clamped = Math.max(0, Math.min(totalDuration, raw));
+  function snapTimelineTime(raw: number, width: number, excludeClipId = '', maxTime = totalDuration): number {
+    const clamped = Math.max(0, Math.min(maxTime, raw));
     const fps = scene?.canvas.fps ?? 60;
     const frameTime = Math.round(clamped * fps) / fps;
     if (!snapEnabled) {
@@ -2411,7 +2529,7 @@
     }
     const nearest = candidates.reduce((best, value) =>
       Math.abs(value - clamped) < Math.abs(best - clamped) ? value : best, 0);
-    const snapped = Math.abs(nearest - clamped) <= (totalDuration * 8) / Math.max(1, width);
+    const snapped = Math.abs(nearest - clamped) <= (timelineVisibleDuration * 8) / Math.max(1, width);
     timelineSnapGuide = snapped ? nearest : null;
     return snapped ? nearest : frameTime;
   }
@@ -2868,7 +2986,7 @@
       }
       if (!node || !frame) return;
       const timing = selectedAnimationTiming(node);
-      const raw = ((pointer.clientX - rect.left) / rect.width) * totalDuration;
+      const raw = ((pointer.clientX - rect.left) / rect.width) * timelineVisibleDuration;
       const snappedTime = snapTimelineTime(raw, rect.width);
       const nextOffset = keyframeOffsetAtTime(snappedTime, timing.delay, timing.duration);
       frame.offset = nextOffset;
@@ -3171,7 +3289,7 @@
     {snapEnabled}
     {timelineZoom}
     {timelineContentWidth}
-    {totalDuration}
+    {timelineVisibleDuration}
     {scene}
     draggingAsset={draggingAsset !== null}
     {draggingAudio}

--- a/src/ui/components/motion-editor/TimelinePanel.svelte
+++ b/src/ui/components/motion-editor/TimelinePanel.svelte
@@ -22,7 +22,7 @@
   export let snapEnabled: boolean;
   export let timelineZoom: number;
   export let timelineContentWidth: number;
-  export let totalDuration: number;
+  export let timelineVisibleDuration: number;
   export let scene: Scene | null;
   export let draggingAsset: boolean;
   export let draggingAudio: boolean;
@@ -169,7 +169,7 @@
           {#if dropTargetTime !== null}
             <span class="me-drop-indicator" style={`left: ${timelinePercent(dropTargetTime)}%`}></span>
           {/if}
-          <input class="me-timeline-scrubber" type="range" min="0" max={totalDuration} step={1 / (scene?.canvas.fps ?? 60)} value={currentTime} on:input={onSeek} aria-label="Timeline scrubber" />
+          <input class="me-timeline-scrubber" type="range" min="0" max={timelineVisibleDuration} step={1 / (scene?.canvas.fps ?? 60)} value={currentTime} on:input={onSeek} aria-label="Timeline scrubber" />
         </div>
       </div>
 

--- a/src/ui/components/motion-editor/timeline-panel.css
+++ b/src/ui/components/motion-editor/timeline-panel.css
@@ -147,7 +147,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: flex-start;
   overflow: auto;
   scrollbar-width: thin;
   scrollbar-color: #34373d #0d0e10;
@@ -155,10 +155,10 @@
 
 .motion-editor-scope .me-ruler-row,
 .motion-editor-scope .me-timeline-row {
-  width: 100%;
-  min-width: var(--timeline-content-width, 820px);
+  width: var(--timeline-content-width, 820px);
+  min-width: 100%;
   display: grid;
-  grid-template-columns: 220px minmax(600px, 1fr);
+  grid-template-columns: 220px calc(var(--timeline-content-width, 820px) - 220px);
 }
 
 .motion-editor-scope .me-ruler-row {

--- a/tests/ui/motion-editor-components.test.ts
+++ b/tests/ui/motion-editor-components.test.ts
@@ -386,6 +386,278 @@ text title { value "Title" x 0 y 0 }`,
     await unmount(instance);
   });
 
+  it('scales the timeline width to the project duration', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+
+    function timelineWidth(host: HTMLElement): number {
+      const scroll = host.querySelector<HTMLElement>('.me-timeline-scroll');
+      if (!scroll) throw new Error('Timeline scroll missing');
+      const value = scroll.style.getPropertyValue('--timeline-content-width');
+      return Number.parseFloat(value);
+    }
+
+    function clipWidthPercent(host: HTMLElement): number {
+      const clip = host.querySelector<HTMLElement>('.me-element-clip');
+      if (!clip) throw new Error('Element clip missing');
+      const match = /width:\s*([\d.]+)%/.exec(clip.getAttribute('style') ?? '');
+      if (!match) throw new Error('Clip width not found');
+      return Number.parseFloat(match[1]);
+    }
+
+    // A short (1s) project keeps the clip bar short relative to the ruler; at
+    // rest there is no trailing padding.
+    const shortHost = target();
+    const shortEditor = mount(MotionEditor, {
+      target: shortHost,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 1s background #000000 }
+text title { value "Hi" }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+    const shortWidth = timelineWidth(shortHost);
+    const shortClipPercent = clipWidthPercent(shortHost);
+
+    // ...while a longer (12s) project produces a proportionally wider timeline
+    // whose clip does fill the (still fixed-scale) visible duration.
+    const longHost = target();
+    const longEditor = mount(MotionEditor, {
+      target: longHost,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 12s background #000000 }
+text title { value "Hi" }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+    const longWidth = timelineWidth(longHost);
+
+    // The ruler spans the content end + a fixed 20s tail (at 100px/s + 220px
+    // At rest the ruler spans the content (or the panel if the content is
+    // shorter) with no trailing padding, at 100px/s + a 220px label. In jsdom
+    // the panel measures 0, so a 12s project is 12s wide and a 1s project falls
+    // back to the tiny panel-fill floor — both far from the old 820px minimum.
+    expect(longWidth).toBeGreaterThan(shortWidth);
+    expect(longWidth).toBeCloseTo(220 + 12 * 100, 0);
+    expect(shortWidth).toBeLessThan(820);
+
+    // The 1s clip only covers its own duration within the ruler (well under 100%).
+    expect(shortClipPercent).toBeLessThan(100);
+    expect(shortClipPercent).toBeCloseTo(62.5, 1);
+
+    // Zoom in/out must rescale the timeline width around that base scale.
+    const zoomIn = longHost.querySelector<HTMLElement>('[title="Timeline zoom in"]');
+    const zoomOut = longHost.querySelector<HTMLElement>('[title="Timeline zoom out"]');
+    if (!zoomIn || !zoomOut) throw new Error('Timeline zoom controls missing');
+
+    click(zoomIn);
+    await tick();
+    const zoomedInWidth = timelineWidth(longHost);
+    expect(zoomedInWidth).toBeGreaterThan(longWidth);
+    expect(zoomedInWidth).toBeCloseTo(220 + 12 * 100 * 1.25, 0);
+
+    click(zoomOut);
+    await tick();
+    expect(timelineWidth(longHost)).toBeCloseTo(longWidth, 0);
+
+    await unmount(shortEditor);
+    await unmount(longEditor);
+  });
+
+  it('drags a full-duration clip into the empty time and extends the project', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.stubGlobal('CSS', { escape: (value: string) => value });
+    (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () =>
+      null;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    // Give the timeline a real width so the visible duration exceeds the 5s project.
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 2000,
+    });
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+      () =>
+        ({
+          left: 0,
+          top: 0,
+          right: 1000,
+          bottom: 40,
+          width: 1000,
+          height: 40,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect
+    );
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 5s background #000000 }
+text title { value "Hi" }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+    await tick();
+
+    const grip = host.querySelector<HTMLElement>('.me-element-clip .me-clip-select');
+    if (!grip) throw new Error('Clip grip missing');
+
+    // Grab near the clip start and drag well to the right (500px of a 1000px,
+    // 17.8s-visible lane ≈ 8.9s), which places a 5s clip past the 5s project end.
+    grip.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0, clientX: 50 }));
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 500 }));
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 500 }));
+    await tick();
+
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const source = host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value ?? '';
+
+    // The element must have moved to a later start...
+    const startMatch = /start\s+([\d.]+)s/.exec(source);
+    expect(startMatch).not.toBeNull();
+    expect(Number.parseFloat(startMatch![1])).toBeGreaterThan(5);
+    // ...and the project duration must have grown to contain it.
+    const durationMatch = /duration\s+([\d.]+)s/.exec(source);
+    expect(durationMatch).not.toBeNull();
+    expect(Number.parseFloat(durationMatch![1])).toBeGreaterThan(5);
+
+    delete (HTMLElement.prototype as unknown as { clientWidth?: unknown }).clientWidth;
+    await unmount(instance);
+  });
+
+  it('extends a text clip (and the project) when dragging its end past the project', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.stubGlobal('CSS', { escape: (value: string) => value });
+    (document as unknown as { elementFromPoint: () => Element | null }).elementFromPoint = () =>
+      null;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 2000,
+    });
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+      () =>
+        ({
+          left: 0,
+          top: 0,
+          right: 1000,
+          bottom: 40,
+          width: 1000,
+          height: 40,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect
+    );
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 5s background #000000 }
+text title { value "Hi" }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+    await tick();
+
+    const trimEnd = host.querySelector<HTMLElement>('.me-element-clip .me-trim-end');
+    if (!trimEnd) throw new Error('Trim-end handle missing');
+
+    // Drag the right edge to ~800px of a 1000px, 17.8s-visible lane (≈14s).
+    trimEnd.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, button: 0, clientX: 400 })
+    );
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 800 }));
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 800 }));
+    await tick();
+
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const source = host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value ?? '';
+
+    // The clip and the canvas duration must both have grown past the original 5s.
+    const durations = Array.from(source.matchAll(/duration\s+([\d.]+)s/g)).map((m) =>
+      Number.parseFloat(m[1])
+    );
+    expect(durations.length).toBeGreaterThan(0);
+    expect(Math.max(...durations)).toBeGreaterThan(5);
+
+    delete (HTMLElement.prototype as unknown as { clientWidth?: unknown }).clientWidth;
+    await unmount(instance);
+  });
+
+  it('clamps the playhead to the content end, not the padded ruler tail', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    // A wide panel makes the ruler span more than the 5s content, so the
+    // scrubber's max exceeds the content end and we can test the clamp.
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 2000,
+    });
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 5s background #000000 }
+text title { value "Hi" }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+
+    const scrubber = host.querySelector<HTMLInputElement>('.me-timeline-scrubber');
+    if (!scrubber) throw new Error('Timeline scrubber missing');
+    // Seek to the far end of the ruler; the playhead must clamp to the 5s
+    // content end (frame 150 at 30fps), not the ruler tail.
+    scrubber.value = scrubber.max;
+    scrubber.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+
+    const framecode = host.querySelector('.me-framecode')?.textContent ?? '';
+    expect(framecode).toContain('150');
+
+    delete (HTMLElement.prototype as unknown as { clientWidth?: unknown }).clientWidth;
+    await unmount(instance);
+  });
+
   it('shows the evaluated scale while the playhead moves between keyframes', async () => {
     class ResizeObserverStub {
       observe(): void {}


### PR DESCRIPTION
## Summary
This PR fixes issues #50 — the timeline scale was too long.

## Changes
- **Fixed pixels-per-second scale** — a clip's width now reflects its real
duration, so short clips render short and long clips render long.
- **No trailing padding at rest** — the ruler spans the content end (or the
panel width if the content is shorter), so there's no confusing empty tail.
- **Dynamic drag-extend** — while dragging/stretching a clip toward the end,
the ruler grows to keep room ahead so it can be extended, and the view
follows the dragged edge. Existing clips keep their pixel position because
the scale is fixed (nothing jumps).
- **Auto-grow the project** — committing a clip past the current end extends
the project (canvas duration) to contain it, keeping ~a screen of room. The
growth is content-only (no padding written to `canvas.duration`), so export
behavior is unchanged.
- **Playhead clamped to the last clipbar end**, not the ruler tail.
- **Working zoom** — zoom in/out now visibly rescales the lane at any duration.

## Files
- `src/ui/components/MotionEditor.svelte` — scale/visible-duration/content-end
computation, drag/trim/move clamps, `extendProjectDuration`,
`followTimelineDrag`, playhead clamp.
- `src/ui/components/motion-editor/TimelinePanel.svelte` — scrubber range,
`timelineVisibleDuration` prop.
- `src/ui/components/motion-editor/timeline-panel.css` — content-width rows
instead of a stretched `1fr` lane.
- `tests/ui/motion-editor-components.test.ts` — new tests.

## Testing
- `npm run test:run` — 197 passed (39 files), including new tests for duration
scaling, zoom in/out, drag into empty time, text-clip extend, and playhead
clamping.
- `npm run build` — clean (`tsc` + `vite build`).