### PR TITLE
fix(editor): make keyboard shortcuts work globally without requiring Esp first 

### DIFF
--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -44,7 +44,7 @@
   import { elementWindowProperties, moveElementClip, splitElementClip } from '../element-clips';
   import { restoreEmbeddedAssetPaths } from '../../ai/chat';
   import { createEditorHistory, recordEditorSource, redoEditorSource, undoEditorSource } from '../editor-history';
-  import { editorShortcut } from '../editor-shortcuts';
+  import { editorShortcut, shortcutContext } from '../editor-shortcuts';
   import { cloneClipInProgram, cloneElementInProgram } from '../duplicate-cloning';
   import { extractAudioPeaks, waveformBucketCount, waveformPath } from '../audio-waveform';
   import { moveClipToTrack, removeClipFromTracks, trimClipOnTrack } from '../timeline-tracks';
@@ -235,11 +235,12 @@
     requestAnimationFrame(measureTimeline);
     
     const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target instanceof Element ? e.target : null;
-      const interactive = Boolean(target?.closest(
-        'input, textarea, select, button, a, [contenteditable="true"], [role="button"], [role="slider"]'
-      ));
-      const shortcut = editorShortcut(e, interactive);
+      const context = shortcutContext(e.target);
+      if (e.key === 'Escape' && context !== 'global' && e.target instanceof HTMLElement) {
+        e.target.blur();
+        if (context === 'typing') return;
+      }
+      const shortcut = editorShortcut(e, context);
       if (!shortcut || showConfirmDialog) return;
       e.preventDefault();
       if (e.repeat && !shortcut.startsWith('nudge-')) return;

--- a/src/ui/editor-shortcuts.ts
+++ b/src/ui/editor-shortcuts.ts
@@ -13,22 +13,74 @@ export type EditorShortcut =
   | 'toggle-playback'
   | 'undo';
 
+/**
+ * Where keyboard focus currently sits, from the shortcut system's viewpoint:
+ * - 'typing': a text-entry field — shortcuts must not fire while typing
+ * - 'arrow-control': a control that consumes arrow keys (slider, select, radio)
+ * - 'control': a clickable control that only consumes Space/Enter (button, link)
+ * - 'global': anything else — every shortcut applies
+ */
+export type ShortcutContext = 'arrow-control' | 'control' | 'global' | 'typing';
+
 type ShortcutEvent = Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>;
 
-export function editorShortcut(event: ShortcutEvent, interactive = false): EditorShortcut | null {
+// Input types that behave like buttons rather than text entry.
+const CLICKY_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'image',
+  'reset',
+  'submit',
+]);
+
+const ARROW_CONTROL_SELECTOR =
+  'select, audio, video, [role="slider"], [role="spinbutton"], [role="radio"], [role="tab"], [role="menuitem"], [role="option"], [role="listbox"], [role="menu"]';
+
+const CONTROL_SELECTOR =
+  'button, a, summary, [role="button"], [role="checkbox"], [role="switch"], [role="link"]';
+
+const EDITABLE_SELECTOR =
+  '[contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]';
+
+export function shortcutContext(target: EventTarget | null | undefined): ShortcutContext {
+  if (typeof Element === 'undefined' || !(target instanceof Element)) return 'global';
+  if (target.tagName === 'TEXTAREA') return 'typing';
+  if (target.tagName === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    if (type === 'range' || type === 'radio') return 'arrow-control';
+    return CLICKY_INPUT_TYPES.has(type) ? 'control' : 'typing';
+  }
+  if ((target as HTMLElement).isContentEditable || target.closest(EDITABLE_SELECTOR))
+    return 'typing';
+  if (target.closest(ARROW_CONTROL_SELECTOR)) return 'arrow-control';
+  if (target.closest(CONTROL_SELECTOR)) return 'control';
+  return 'global';
+}
+
+export function editorShortcut(
+  event: ShortcutEvent,
+  context: ShortcutContext = 'global'
+): EditorShortcut | null {
   const command = event.ctrlKey || event.metaKey;
   const key = event.key.toLowerCase();
+  const typing = context === 'typing';
 
   if (command) {
     if (!event.altKey && !event.shiftKey && key === 's') return 'save';
-    if (!event.altKey && !event.shiftKey && !interactive && key === 'd')
-      return 'duplicate-selection';
-    if (!event.altKey && !interactive && key === 'z') return event.shiftKey ? 'redo' : 'undo';
+    if (typing) return null;
+    if (!event.altKey && !event.shiftKey && key === 'd') return 'duplicate-selection';
+    if (!event.altKey && key === 'z') return event.shiftKey ? 'redo' : 'undo';
     return null;
   }
-  if (interactive || event.altKey) return null;
+  if (typing || event.altKey) return null;
 
-  if (event.key === ' ') return 'toggle-playback';
+  // Focused controls keep the keys they respond to natively: Space activates
+  // buttons and arrows drive sliders/selects/radios.
+  if (event.key === ' ') return context === 'global' ? 'toggle-playback' : null;
+  if (event.key.startsWith('Arrow') && context === 'arrow-control') return null;
+
   if (event.key === 'Delete' || event.key === 'Backspace') return 'delete-selection';
   if (event.key === 'ArrowLeft') return 'nudge-left';
   if (event.key === 'ArrowRight') return 'nudge-right';

--- a/tests/ui/editor-shortcuts.test.ts
+++ b/tests/ui/editor-shortcuts.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { editorShortcut } from '../../src/ui/editor-shortcuts';
+import {
+  editorShortcut,
+  shortcutContext,
+  type ShortcutContext,
+} from '../../src/ui/editor-shortcuts';
 
 const key = (
   value: string,
   overrides: Partial<Parameters<typeof editorShortcut>[0]> = {},
-  interactive = false
+  context: ShortcutContext = 'global'
 ) =>
   editorShortcut(
     {
@@ -15,7 +19,7 @@ const key = (
       shiftKey: false,
       ...overrides,
     },
-    interactive
+    context
   );
 
 describe('editor shortcuts', () => {
@@ -33,11 +37,72 @@ describe('editor shortcuts', () => {
     expect(key('z', { metaKey: true, shiftKey: true })).toBe('redo');
   });
 
-  it('leaves typing and focused controls alone except for save', () => {
-    expect(key(' ', {}, true)).toBeNull();
-    expect(key('Backspace', {}, true)).toBeNull();
-    expect(key('z', { ctrlKey: true }, true)).toBeNull();
-    expect(key('s', { ctrlKey: true }, true)).toBe('save');
-    expect(key('d', { ctrlKey: true }, true)).toBeNull();
+  it('leaves typing alone except for save', () => {
+    expect(key(' ', {}, 'typing')).toBeNull();
+    expect(key('Backspace', {}, 'typing')).toBeNull();
+    expect(key('Escape', {}, 'typing')).toBeNull();
+    expect(key('z', { ctrlKey: true }, 'typing')).toBeNull();
+    expect(key('d', { ctrlKey: true }, 'typing')).toBeNull();
+    expect(key('s', { ctrlKey: true }, 'typing')).toBe('save');
+  });
+
+  it('keeps shortcuts working while a button is focused, except Space', () => {
+    expect(key('z', { ctrlKey: true }, 'control')).toBe('undo');
+    expect(key('z', { ctrlKey: true, shiftKey: true }, 'control')).toBe('redo');
+    expect(key('d', { ctrlKey: true }, 'control')).toBe('duplicate-selection');
+    expect(key('Delete', {}, 'control')).toBe('delete-selection');
+    expect(key('ArrowLeft', {}, 'control')).toBe('nudge-left');
+    expect(key('s', {}, 'control')).toBe('split');
+    expect(key('Escape', {}, 'control')).toBe('clear-selection');
+    expect(key(' ', {}, 'control')).toBeNull();
+  });
+
+  it('leaves arrows and Space to sliders and selects', () => {
+    expect(key('ArrowLeft', {}, 'arrow-control')).toBeNull();
+    expect(key('ArrowUp', {}, 'arrow-control')).toBeNull();
+    expect(key(' ', {}, 'arrow-control')).toBeNull();
+    expect(key('z', { ctrlKey: true }, 'arrow-control')).toBe('undo');
+    expect(key('Delete', {}, 'arrow-control')).toBe('delete-selection');
+  });
+});
+
+describe('shortcut context classification', () => {
+  const element = (html: string): Element => {
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    return host.querySelector('[data-target]') ?? host.firstElementChild!;
+  };
+
+  it('treats text entry as typing', () => {
+    expect(shortcutContext(element('<textarea></textarea>'))).toBe('typing');
+    expect(shortcutContext(element('<input type="text">'))).toBe('typing');
+    expect(shortcutContext(element('<input type="number">'))).toBe('typing');
+    expect(shortcutContext(element('<input type="search">'))).toBe('typing');
+    expect(shortcutContext(element('<div contenteditable="true"></div>'))).toBe('typing');
+    expect(
+      shortcutContext(element('<div contenteditable="true"><span data-target>x</span></div>'))
+    ).toBe('typing');
+  });
+
+  it('treats buttons and links as controls, not typing', () => {
+    expect(shortcutContext(element('<button></button>'))).toBe('control');
+    expect(shortcutContext(element('<button><span data-target></span></button>'))).toBe('control');
+    expect(shortcutContext(element('<a href="#"></a>'))).toBe('control');
+    expect(shortcutContext(element('<div role="button"></div>'))).toBe('control');
+    expect(shortcutContext(element('<input type="checkbox">'))).toBe('control');
+  });
+
+  it('treats arrow-consuming controls separately', () => {
+    expect(shortcutContext(element('<select></select>'))).toBe('arrow-control');
+    expect(shortcutContext(element('<input type="range">'))).toBe('arrow-control');
+    expect(shortcutContext(element('<input type="radio">'))).toBe('arrow-control');
+    expect(shortcutContext(element('<div role="slider"></div>'))).toBe('arrow-control');
+  });
+
+  it('treats everything else as global', () => {
+    expect(shortcutContext(null)).toBe('global');
+    expect(shortcutContext(document.body)).toBe('global');
+    expect(shortcutContext(element('<canvas></canvas>'))).toBe('global');
+    expect(shortcutContext(element('<div tabindex="0"></div>'))).toBe('global');
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #60: editor keyboard shortcuts no longer require pressing `Esc` or focusing a specific panel first.
- Root cause: nearly every editor surface (play button, timeline clips, trim handles, toolbar icons) is a `<button>`, so a single click left focus on it — and the old `interactive` flag treated any focused control like a text field, disabling every shortcut.
- Replaced that boolean with a focus-context classifier in `src/ui/editor-shortcuts.ts`: `typing`, `arrow-control`, `control`, `global`.
- Undo, redo, duplicate, delete, split, nudge, and Home now fire immediately after clicking a clip or button. Focused controls keep the keys they need — `Space` still activates a focused button, arrows still drive a focused slider, dropdown, or radio.
- While typing in a text field only `Ctrl/Cmd` + `S` applies; `Escape` now also blurs the focused field or control, returning to the full shortcut set in one keystroke.
- Updated `docs/editor/ui-guide.mdx`, which previously documented the old "canvas or timeline has focus" behavior.

## Testing

- `npm run test:run` — 39 files, 203 tests passing.
- `npm run type-check` and `npm run lint` clean (no new warnings).
- Expanded `tests/ui/editor-shortcuts.test.ts` from 2 to 8 tests: the full shortcut matrix per focus context, plus DOM classification of text inputs, buttons, links, sliders, selects, contenteditable, and nested targets such as an icon `<span>` inside a `<button>`.
- Manually verified in `npm run dev`: click a timeline clip, then `Ctrl/Cmd` + `Z` / `Shift` + `Z` / `D` / `Delete` / arrows / `S` all respond with no `Esc` first; typing in the source editor and property fields is unaffected; `Space` on a focused toolbar button still activates that button.

## Checklist

- [x] I ran `npm test`.
- [x] I kept the change scoped and readable.
- [x] I updated docs for syntax, preset, export, or public behavior changes.
- [x] I did not mutate imported assets or add hidden renderer state.