### PR TITLE
fix(timeline): default new stills and text to 3s instead of the full timeline 

### DIFF
--- a/src/scene/scene-graph.ts
+++ b/src/scene/scene-graph.ts
@@ -373,6 +373,21 @@ export function assetType(path: string): AssetType {
   return 'image';
 }
 
+/**
+ * Sources that carry their own length (video, GIF, Lottie) and should be placed
+ * at that length. Everything else — stills, SVG — is static and gets the
+ * editor's default duration. GIFs share the `image` asset type, so the
+ * extension has to be checked separately.
+ */
+export function hasIntrinsicDuration(path: string): boolean {
+  const type = assetType(path);
+  if (type === 'video' || type === 'lottie') return true;
+  const lower = path.toLowerCase();
+  const filename = assetFilename(path).toLowerCase();
+  const pathname = lower.split(/[?#]/, 1)[0] ?? lower;
+  return lower.startsWith('data:image/gif') || (filename || pathname).endsWith('.gif');
+}
+
 /** Validate serializable layer-mask references before rendering. */
 export function validateElementMasks(elements: Element[]): void {
   const byId = new Map(elements.map((element) => [element.id, element]));

--- a/src/ui/clip-timing.ts
+++ b/src/ui/clip-timing.ts
@@ -10,6 +10,12 @@ export interface PlacedMediaClip {
 
 const DEFAULT_MINIMUM_DURATION = 1 / 60;
 
+/**
+ * Timeline length given to content that carries no length of its own — stills,
+ * SVG, text. Videos, GIFs, Lottie and audio bring their own duration instead.
+ */
+export const DEFAULT_STATIC_DURATION = 3;
+
 function finite(value: number, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
 }
@@ -30,17 +36,24 @@ function normalized(clip: ClipTiming): ClipTiming {
   };
 }
 
-/** Place imported media at full source length, extending the project instead of trimming it. */
+/**
+ * Place imported media at full source length, extending the project instead of
+ * trimming it. Sources without a length of their own (stills, SVG) get the
+ * short static default rather than the whole timeline.
+ */
 export function placeMediaClip(
   requestedStart: number,
   sourceDuration: number,
   timelineDuration: number,
-  fallbackDuration = 5,
+  fallbackDuration = DEFAULT_STATIC_DURATION,
   minimum = DEFAULT_MINIMUM_DURATION
 ): PlacedMediaClip {
   const currentTimeline = Math.max(0, finite(timelineDuration, 0));
   const start = Math.min(currentTimeline, Math.max(0, finite(requestedStart, 0)));
-  const fallback = Math.max(minimumDuration(minimum), finite(fallbackDuration, 5));
+  const fallback = Math.max(
+    minimumDuration(minimum),
+    finite(fallbackDuration, DEFAULT_STATIC_DURATION)
+  );
   const duration = Math.max(
     minimumDuration(minimum),
     finite(sourceDuration, 0) > 0 ? sourceDuration : fallback
@@ -67,42 +80,52 @@ export function moveClip(
 /**
  * Move the left timeline edge. Positive deltas consume source at the beginning;
  * negative deltas restore available trimIn. trimIn + duration remains constant.
+ *
+ * `staticSource` marks content with no source timeline to run out of (a still,
+ * an SVG): its edge moves freely back to time 0 and trimIn stays untouched.
  */
 export function trimClipStart(
   input: ClipTiming,
   requestedStart: number,
-  minimum = DEFAULT_MINIMUM_DURATION
+  minimum = DEFAULT_MINIMUM_DURATION,
+  staticSource = false
 ): ClipTiming {
   const clip = normalized(input);
   const min = Math.min(clip.duration, minimumDuration(minimum));
   const requestedDelta = finite(requestedStart, clip.start) - clip.start;
-  const delta = Math.min(clip.duration - min, Math.max(-clip.trimIn, requestedDelta));
+  const earliestDelta = staticSource ? -clip.start : -clip.trimIn;
+  const delta = Math.min(clip.duration - min, Math.max(earliestDelta, requestedDelta));
   return {
     ...clip,
     start: clip.start + delta,
     duration: clip.duration - delta,
-    trimIn: clip.trimIn + delta,
+    trimIn: staticSource ? clip.trimIn : clip.trimIn + delta,
   };
 }
 
 /**
  * Move the right timeline edge. Extending consumes trimOut; shortening adds it.
  * duration + trimOut remains constant.
+ *
+ * `staticSource` marks content with no source timeline to run out of, so it can
+ * be stretched to any length instead of being capped by the remaining trimOut.
  */
 export function trimClipEnd(
   input: ClipTiming,
   requestedEnd: number,
-  minimum = DEFAULT_MINIMUM_DURATION
+  minimum = DEFAULT_MINIMUM_DURATION,
+  staticSource = false
 ): ClipTiming {
   const clip = normalized(input);
   const min = Math.min(clip.duration, minimumDuration(minimum));
   const currentEnd = clip.start + clip.duration;
   const requestedDelta = finite(requestedEnd, currentEnd) - currentEnd;
-  const delta = Math.min(clip.trimOut, Math.max(min - clip.duration, requestedDelta));
+  const bounded = Math.max(min - clip.duration, requestedDelta);
+  const delta = staticSource ? bounded : Math.min(clip.trimOut, bounded);
   return {
     ...clip,
     duration: clip.duration + delta,
-    trimOut: clip.trimOut - delta,
+    trimOut: staticSource ? clip.trimOut : clip.trimOut - delta,
   };
 }
 

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { Sparkles } from 'lucide-svelte';
   import { parseMotion } from '../../language/parser';
-  import { buildSceneGraph } from '../../scene/scene-graph';
+  import { buildSceneGraph, hasIntrinsicDuration } from '../../scene/scene-graph';
   import { evaluateScene } from '../../animation/evaluator';
   import {
     assetWarnings,
@@ -34,7 +34,7 @@
     setKeyframeEasing,
     upsertKeyframe,
   } from '../keyframe-editing';
-  import { placeMediaClip, splitClip, type ClipTiming } from '../clip-timing';
+  import { DEFAULT_STATIC_DURATION, placeMediaClip, splitClip, type ClipTiming } from '../clip-timing';
   import {
     adjacentClipBoundaries,
     applyClipTransition,
@@ -1579,9 +1579,21 @@
     previewAsset = null;
   }
 
+  /**
+   * Source length in seconds, or 0 for static media (stills, SVG) that has no
+   * length of its own. Drives both the placed duration and whether a clip edge
+   * can be dragged past the source it was cut from.
+   */
+  function assetSourceDuration(assetName: string): number {
+    const duration = assets.get(assetName)?.motionlyDuration ?? 0;
+    return Number.isFinite(duration) && duration > 0 ? duration : 0;
+  }
+
   function handleAssetDragStart(event: DragEvent, asset: Asset) {
     const loaded = assets.get(asset.name);
-    if (!loaded || (asset.type === 'video' && !loaded.motionlyDuration)) {
+    // Video/GIF/Lottie must be placed at their own length, so wait for the
+    // decoder to report one instead of falling back to the static default.
+    if (!loaded || (hasIntrinsicDuration(asset.path) && !loaded.motionlyDuration)) {
       event.preventDefault();
       assetError = `${asset.name} is still loading. Try again in a moment.`;
       return;
@@ -1826,12 +1838,11 @@
     const assetName = draggingAsset.name;
     ensureAssetElement(assetName);
     const frame = 1 / (scene?.canvas.fps ?? 60);
-    const loadedAsset = assets.get(assetName);
     const placement = placeMediaClip(
       dropTargetTime,
-      loadedAsset?.motionlyDuration ?? 0,
+      assetSourceDuration(assetName),
       totalDuration,
-      5,
+      DEFAULT_STATIC_DURATION,
       frame
     );
     const { start, duration } = placement;
@@ -2068,8 +2079,11 @@
       selectedClip.id,
       'end',
       requestedEnd,
-      1 / scene.canvas.fps
+      1 / scene.canvas.fps,
+      assetSourceDuration(selectedClip.assetName) === 0
     );
+    const resized = next.find((candidate) => candidate.id === selectedClip?.id);
+    if (resized) extendProjectDuration(resized.start + resized.duration);
     writeClipLayout(next);
   }
 
@@ -2424,6 +2438,8 @@
     const trackId = laneEl.dataset['track'] ?? '';
     beginHistoryGesture();
     const minimum = 1 / (scene?.canvas.fps ?? 60);
+    // Stills have no source to run out of, so their edges stretch freely.
+    const staticSource = assetSourceDuration(clip.assetName) === 0;
     const move = (pointer: PointerEvent) => {
       const rect = timelineLaneRect(trackId) ?? laneEl.getBoundingClientRect();
       const raw = ((pointer.clientX - rect.left) / rect.width) * timelineVisibleDuration;
@@ -2434,7 +2450,8 @@
         clip.id,
         edge,
         time,
-        minimum
+        minimum,
+        staticSource
       );
       const trimmed = next.find((candidate) => candidate.id === clip.id);
       if (trimmed) {
@@ -3028,6 +3045,12 @@
   function addTextElement() {
     if (!ast) return;
     const name = nextElementName('text');
+    // Text carries no length of its own: give it the short static default
+    // rather than the whole project, and only shorten it on a tiny timeline.
+    const duration = Math.max(
+      1 / (scene?.canvas.fps ?? 60),
+      Math.min(DEFAULT_STATIC_DURATION, totalDuration)
+    );
     ast.body.push({
       type: 'Element',
       kind: 'text',
@@ -3040,7 +3063,7 @@
         color: '#ffffff',
         opacity: 1,
         start: '0s',
-        duration: `${totalDuration.toFixed(3)}s`,
+        duration: `${duration.toFixed(3)}s`,
         track: defaultMainTrack,
       },
     });

--- a/src/ui/components/motion-editor/PropertiesInspector.svelte
+++ b/src/ui/components/motion-editor/PropertiesInspector.svelte
@@ -568,7 +568,8 @@
             <div class="me-property-group">
               <div class="me-property-label">Duration</div>
               <div class="me-number-input-wrapper">
-                <input class="me-number-input" type="number" min="0.05" max={totalDuration} step="0.05" value={selectedClip.duration} on:change={(event) => onResizeSelectedClip(Number(event.currentTarget.value))} />
+                <!-- No max: a still can be stretched past the project end, which grows the project. Media is clamped to its source length by the resize handler. -->
+                <input class="me-number-input" type="number" min="0.05" step="0.05" value={selectedClip.duration} on:change={(event) => onResizeSelectedClip(Number(event.currentTarget.value))} />
                 <span class="me-input-suffix">s</span>
               </div>
             </div>

--- a/src/ui/timeline-tracks.ts
+++ b/src/ui/timeline-tracks.ts
@@ -25,14 +25,15 @@ export function trimClipOnTrack(
   clipId: string,
   edge: 'start' | 'end',
   requestedTime: number,
-  minimum: number
+  minimum: number,
+  staticSource = false
 ): Clip[] {
   return clips.map((clip) => {
     if (clip.id !== clipId) return clip;
     const timing =
       edge === 'start'
-        ? trimClipStart(clip as ClipTiming, requestedTime, minimum)
-        : trimClipEnd(clip as ClipTiming, requestedTime, minimum);
+        ? trimClipStart(clip as ClipTiming, requestedTime, minimum, staticSource)
+        : trimClipEnd(clip as ClipTiming, requestedTime, minimum, staticSource);
     return { ...clip, ...timing };
   });
 }

--- a/tests/assets/video-assets.test.ts
+++ b/tests/assets/video-assets.test.ts
@@ -7,7 +7,7 @@ import {
   videoSourceTime,
   type LoadedAsset,
 } from '../../src/assets/asset-loader';
-import { assetType } from '../../src/scene/scene-graph';
+import { assetType, hasIntrinsicDuration } from '../../src/scene/scene-graph';
 import type { EvaluatedScene } from '../../src/types/scene';
 
 describe('animated assets', () => {
@@ -30,6 +30,19 @@ describe('animated assets', () => {
     );
     expect(assetType('/media/loop.gif')).toBe('image');
     expect(assetType('/media/photo.png')).toBe('image');
+  });
+
+  it('separates sources that carry their own length from static artwork', () => {
+    expect(hasIntrinsicDuration('/media/intro.mp4')).toBe(true);
+    expect(hasIntrinsicDuration('/media/loader.lottie')).toBe(true);
+    // GIFs share the `image` asset type but still play a timeline of their own.
+    expect(hasIntrinsicDuration('/media/loop.GIF?version=2')).toBe(true);
+    expect(hasIntrinsicDuration('data:image/gif;base64,AAAA')).toBe(true);
+    expect(
+      hasIntrinsicDuration('data:application/octet-stream;base64,AAAA#motionly-filename=loop.gif')
+    ).toBe(true);
+    expect(hasIntrinsicDuration('/media/photo.png')).toBe(false);
+    expect(hasIntrinsicDuration('/media/logo.svg')).toBe(false);
   });
 
   it('maps timeline time to variable-duration GIF frames', () => {

--- a/tests/ui/clip-timing.test.ts
+++ b/tests/ui/clip-timing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DEFAULT_STATIC_DURATION,
   moveClip,
   placeMediaClip,
   splitClip,
@@ -33,6 +34,18 @@ describe('clip timing edits', () => {
     });
   });
 
+  it('gives static media the short default instead of the whole timeline', () => {
+    expect(DEFAULT_STATIC_DURATION).toBe(3);
+    // A still dropped at the start of a long project stays 3s, not 30s.
+    expect(placeMediaClip(0, 0, 30)).toEqual({
+      start: 0,
+      duration: 3,
+      timelineDuration: 30,
+    });
+    // Timed sources still win over the default.
+    expect(placeMediaClip(0, 12, 30).duration).toBe(12);
+  });
+
   it('moves only the project range and allows the source to extend past the timeline', () => {
     expect(moveClip(clip, 8, 10)).toEqual({ ...clip, start: 8 });
     expect(moveClip(clip, -2, 10)).toEqual({ ...clip, start: 0 });
@@ -56,6 +69,48 @@ describe('clip timing edits', () => {
     const restored = trimClipEnd(clip, 8, 0.25);
     expect(restored).toEqual({ start: 2, duration: 6, trimIn: 1, trimOut: 0 });
     expect(sourceSpan(restored)).toBe(sourceSpan(clip));
+  });
+
+  it('lets a static source stretch past the source window it was placed with', () => {
+    const still: ClipTiming = { start: 2, duration: 3, trimIn: 0, trimOut: 0 };
+    // A timed source cannot grow past its remaining trimOut...
+    expect(trimClipEnd(still, 20, 0.25)).toEqual(still);
+    // ...but a still has no source end, so the edge follows the pointer.
+    expect(trimClipEnd(still, 20, 0.25, true)).toEqual({
+      start: 2,
+      duration: 18,
+      trimIn: 0,
+      trimOut: 0,
+    });
+    expect(trimClipStart(still, 0, 0.25, true)).toEqual({
+      start: 0,
+      duration: 5,
+      trimIn: 0,
+      trimOut: 0,
+    });
+    // Shortening a still still works, and never banks phantom source.
+    expect(trimClipEnd(still, 3, 0.25, true)).toEqual({
+      start: 2,
+      duration: 1,
+      trimIn: 0,
+      trimOut: 0,
+    });
+    expect(trimClipStart(still, 3, 0.25, true)).toEqual({
+      start: 3,
+      duration: 2,
+      trimIn: 0,
+      trimOut: 0,
+    });
+  });
+
+  it('never drags a static source past the start of the timeline', () => {
+    const still: ClipTiming = { start: 1, duration: 3, trimIn: 0, trimOut: 0 };
+    expect(trimClipStart(still, -5, 0.25, true)).toEqual({
+      start: 0,
+      duration: 4,
+      trimIn: 0,
+      trimOut: 0,
+    });
   });
 
   it('enforces a minimum duration at either edge', () => {

--- a/tests/ui/motion-editor-components.test.ts
+++ b/tests/ui/motion-editor-components.test.ts
@@ -266,6 +266,41 @@ text subtitle { value "Subtitle" center }`,
     await unmount(instance);
   });
 
+  it('gives a new text layer the short static default instead of the whole project', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 20s background #000000 }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+
+    click(host.querySelector('[aria-label="Text"]'));
+    await tick();
+    click(host.querySelector('[title="Add text"]'));
+    await tick();
+
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const source = host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value ?? '';
+    expect(source).toMatch(/text text1 \{[^}]*duration 3\.000s/s);
+    expect(source).not.toMatch(/text text1 \{[^}]*duration 20\.000s/s);
+
+    await unmount(instance);
+  });
+
   it('mounts every major region and keeps nested panel styles isolated', async () => {
     class ResizeObserverStub {
       observe(): void {}

--- a/tests/ui/timeline-tracks.test.ts
+++ b/tests/ui/timeline-tracks.test.ts
@@ -63,4 +63,13 @@ describe('uniform timeline layers', () => {
       ['c', 5],
     ]);
   });
+
+  it('passes the static-source flag through so stills can be lengthened', () => {
+    const still = { ...clip('still', 0, 3), trimOut: 0 };
+    expect(trimClipOnTrack([still], 'still', 'end', 9, 1 / 60)[0]).toMatchObject({ duration: 3 });
+    expect(trimClipOnTrack([still], 'still', 'end', 9, 1 / 60, true)[0]).toMatchObject({
+      duration: 9,
+      trimOut: 0,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- New images and SVG now land on the timeline as 3-second clips instead of the
  old 5s fallback, which filled the entire default project. New text layers get
  the same 3s instead of the full project duration (#55).
- Video, GIF, and Lottie keep placing at their own full source length. The
  "still loading" drag guard only checked `asset.type === 'video'`, so a GIF
  dragged mid-decode silently got the fallback duration — it now covers every
  source that carries its own length via a new `hasIntrinsicDuration()` helper
  (GIFs share the `image` asset type, so the extension needs its own check).
- Made the shorter default usable: `trimClipEnd` caps growth at the clip's
  remaining `trimOut`, which is always 0 for a still, so a 3s image clip would
  have been stuck at 3s forever. `trimClipStart`/`trimClipEnd`/`trimClipOnTrack`
  now take a `staticSource` flag — content with no source timeline stretches
  freely (back to 0 on the left edge) while timed media is unchanged.
- Lengthening a clip from the properties panel now extends the project the same
  way edge-dragging already did, and the artificial `max` on that Duration
  input is gone.

## Testing

- `npm run test:run` — 39 files, 209 tests passing.
- `npm run type-check`, `npm run build`, `npm run lint` — clean (lint reports
  only pre-existing warnings; none in the touched files).
- New coverage: static default and static-stretch cases in
  `tests/ui/clip-timing.test.ts`, the flag pass-through in
  `tests/ui/timeline-tracks.test.ts`, `hasIntrinsicDuration` in
  `tests/assets/video-assets.test.ts`, and a mounted-editor test ass
  text layer serializes `duration 3.000s` on a 20s project.

## Checklist

- [x] I ran `npm test`.
- [x] I kept the change scoped and readable.
- [x] I updated docs for syntax, preset, export, or public behavior changes.
- [x] I did not mutate imported assets or add hidden renderer state.