### PR TITLE
feat(export): add reliable configurable video export

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/bin/ffmpeg-export.js
+++ b/bin/ffmpeg-export.js
@@ -41,6 +41,34 @@ export function createFfmpegExportMiddleware() {
 }
 
 async function handleExportRequest(request, response, url) {
+  if (url.pathname === '/api/exports/ffmpeg') {
+    if (request.method === 'GET') {
+      respond(response, (await ffmpegAvailable()) ? 204 : 503, '');
+      return;
+    }
+    if (request.method === 'POST') {
+      if (
+        request.headers['x-motionly-action'] !== 'install-ffmpeg' ||
+        !sameOrigin(request)
+      ) {
+        respond(response, 403, 'FFmpeg installation was not authorized');
+        return;
+      }
+      await installFfmpeg();
+      if (await ffmpegAvailable()) {
+        respond(response, 204, '');
+      } else {
+        respond(
+          response,
+          202,
+          'FFmpeg was installed, but Motionly must be restarted so the updated PATH is available.'
+        );
+      }
+      return;
+    }
+    respond(response, 405, 'Method not allowed');
+    return;
+  }
   if (request.method === 'POST' && url.pathname === '/api/exports') {
     await createJob(request, response);
     return;
@@ -56,8 +84,12 @@ async function handleExportRequest(request, response, url) {
   if (!job) return respond(response, 404, 'Export job not found');
 
   if (request.method === 'DELETE' && !action) {
-    jobs.delete(id);
-    await rm(job.directory, { recursive: true, force: true });
+    if (job.ffmpeg) {
+      job.ffmpeg.kill();
+    } else {
+      jobs.delete(id);
+      await rm(job.directory, { recursive: true, force: true });
+    }
     respond(response, 204);
     return;
   }
@@ -122,6 +154,11 @@ async function createJob(request, response) {
   const fps = positiveNumber(input.fps, 'fps', 240);
   const duration = positiveNumber(input.duration, 'duration', 24 * 60 * 60);
   const totalFrames = positiveInteger(input.totalFrames, 'totalFrames', 24 * 60 * 60 * 240);
+  const quality = input.quality ?? 'high';
+  if (!['low', 'medium', 'high', 'very-high'].includes(quality)) {
+    throw new Error('Invalid export quality');
+  }
+  const bitrateMbps = positiveNumber(input.bitrateMbps ?? 10, 'bitrate', 200);
   const audioClips = normalizeAudioClips(input, duration);
   const expectedFrames = Math.max(1, Math.ceil(duration * fps));
   if (totalFrames !== expectedFrames) throw new Error(`Expected ${expectedFrames} frames`);
@@ -132,6 +169,8 @@ async function createJob(request, response) {
     fps,
     duration,
     totalFrames,
+    quality,
+    bitrateMbps,
     receivedFrames: new Set(),
     audioClips,
     receivedAudio: new Set(),
@@ -170,7 +209,11 @@ async function finishJob(id, job, response) {
     '-preset',
     'medium',
     '-crf',
-    '18',
+    String(job.quality === 'low' ? 28 : job.quality === 'medium' ? 23 : job.quality === 'high' ? 18 : 15),
+    '-maxrate',
+    `${job.bitrateMbps}M`,
+    '-bufsize',
+    `${job.bitrateMbps * 2}M`,
     '-vf',
     'pad=ceil(iw/2)*2:ceil(ih/2)*2:color=black,format=yuv420p',
     '-frames:v',
@@ -182,22 +225,23 @@ async function finishJob(id, job, response) {
     outputPath
   );
 
-  jobs.delete(id);
   try {
-    await runFfmpeg(args);
+    await runFfmpeg(args, job);
     const output = await stat(outputPath);
     response.statusCode = 200;
     response.setHeader('content-type', 'video/mp4');
     response.setHeader('content-length', String(output.size));
     await pipeline(createReadStream(outputPath), response);
   } finally {
+    jobs.delete(id);
     await rm(job.directory, { recursive: true, force: true });
   }
 }
 
-function runFfmpeg(args) {
+function runFfmpeg(args, job) {
   return new Promise((resolve, reject) => {
     const child = spawn('ffmpeg', args, { windowsHide: true });
+    if (job) job.ffmpeg = child;
     let errorOutput = '';
     child.stderr.setEncoding('utf8');
     child.stderr.on('data', (chunk) => {
@@ -211,10 +255,120 @@ function runFfmpeg(args) {
       );
     });
     child.once('close', (code) => {
+      if (job) job.ffmpeg = null;
       if (code === 0) resolve();
       else reject(new Error(errorOutput.trim() || `ffmpeg exited with code ${String(code)}`));
     });
   });
+}
+
+async function ffmpegAvailable() {
+  try {
+    await runFfmpeg(['-version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function installFfmpeg() {
+  let command;
+  let args;
+  let interactive = false;
+  if (process.platform === 'win32') {
+    command = 'winget';
+    args = [
+      'install',
+      '--id',
+      'Gyan.FFmpeg',
+      '--exact',
+      '--silent',
+      '--accept-package-agreements',
+      '--accept-source-agreements',
+    ];
+  } else if (process.platform === 'darwin') {
+    command = 'brew';
+    args = ['install', 'ffmpeg'];
+  } else if (process.platform === 'linux') {
+    const managers = [
+      ['apt-get', ['install', '-y', 'ffmpeg']],
+      ['dnf', ['install', '-y', 'ffmpeg']],
+      ['yum', ['install', '-y', 'ffmpeg']],
+      ['pacman', ['-S', '--noconfirm', 'ffmpeg']],
+      ['zypper', ['--non-interactive', 'install', 'ffmpeg']],
+      ['apk', ['add', 'ffmpeg']],
+    ];
+    const selected = await firstAvailable(managers);
+    if (!selected) throw new Error('No supported Linux package manager was found');
+    [command, args] = selected;
+    if (typeof process.getuid === 'function' && process.getuid() !== 0) {
+      if (await commandAvailable('pkexec')) {
+        args = [command, ...args];
+        command = 'pkexec';
+      } else {
+        args = [command, ...args];
+        command = 'sudo';
+        interactive = true;
+      }
+    }
+  } else {
+    throw new Error(`Automatic FFmpeg installation is not supported on ${process.platform}`);
+  }
+  try {
+    await runCommand(command, args, interactive);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Automatic FFmpeg installation failed: ${detail}. Install FFmpeg manually, add ffmpeg to PATH, then restart Motionly.`
+    );
+  }
+}
+
+async function firstAvailable(options) {
+  for (const [command, args] of options) {
+    if (await commandAvailable(command)) return [command, args];
+  }
+  return null;
+}
+
+async function commandAvailable(command) {
+  try {
+    await runCommand(command, ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runCommand(command, args, interactive = false) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      windowsHide: true,
+      stdio: interactive ? 'inherit' : 'pipe',
+    });
+    let output = '';
+    for (const stream of [child.stdout, child.stderr]) {
+      stream?.setEncoding('utf8');
+      stream?.on('data', (chunk) => {
+        output = `${output}${chunk}`.slice(-16_384);
+      });
+    }
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(output.trim() || `${command} exited with code ${String(code)}`));
+    });
+  });
+}
+
+function sameOrigin(request) {
+  const origin = request.headers.origin;
+  if (!origin) return true;
+  try {
+    return new URL(origin).host === request.headers.host;
+  } catch {
+    return false;
+  }
 }
 
 async function writeRequest(request, path, maxBytes) {

--- a/docs/export/formats.mdx
+++ b/docs/export/formats.mdx
@@ -1,26 +1,27 @@
 ---
 title: "Export formats: MP4, WebM, GIF, and stills"
-description: Current and planned Motionly export formats, including MP4 output today plus roadmap support for WebM, GIF, PNG stills, and image sequences.
+description: Motionly export formats and their available quality, bitrate, resolution, frame-rate, and audio settings.
 ---
 
 # Export Formats
 
 ## Current
 
-Motionly currently exposes MP4 export from the top toolbar.
+Motionly exposes MP4, WebM, and GIF export from the top toolbar. All three formats support adjustable resolution and frame rate.
 
-The browser evaluates the project at its canvas resolution and FPS, synchronizes animated assets, and sends frames to the local FFmpeg server for MP4 encoding. Project audio is mixed at its persisted start offset.
+- MP4 supports Low, Medium, High, and Very High quality plus adjustable bitrate. It uses local FFmpeg and includes the project audio track.
+- WebM supports adjustable bitrate, uses the browser's MediaRecorder codec, and includes the project audio track when supported.
+- GIF has no video-quality, bitrate, or audio setting.
+
+Export opens a native Save dialog and displays cancellable progress in the center of the editor.
 
 ## Current Limits
 
 - Audio embedded in video clips is muted; use the project audio track for exported sound.
-- Export requires the local Motionly server and FFmpeg.
+- MP4 export requires the local Motionly server and FFmpeg.
+- WebM is unavailable when the browser does not provide a compatible MediaRecorder codec.
 - Animated SVG and GIF fallback use real-time playback because exact seeking is unavailable; Motionly reports this limitation and any CSS-keyframe differences.
-- WebM and GIF code exists internally but is not exposed as a supported editor workflow yet.
 
 ## Planned
 
-- Visual 24, 30, and 60 FPS choices
-- Resolution and aspect-ratio presets
-- 720p, 1080p, 1440p, and 4K output choices
-- WebM, GIF, PNG stills, and image-sequence export
+- PNG still and image-sequence export

--- a/docs/export/overview.mdx
+++ b/docs/export/overview.mdx
@@ -1,34 +1,34 @@
 ---
-title: Exporting .motion projects to MP4
-description: How Motionly exports .motion projects to MP4 using canvas rendering, FFmpeg, project audio, and animated asset syncing, plus roadmap and export rules.
+title: Exporting .motion projects
+description: How Motionly exports .motion projects to MP4, WebM, or GIF with adjustable output settings and cancellable progress.
 ---
 
 # Export
 
 ## Current Editor Support
 
-Motionly currently exposes MP4 export in the top toolbar.
+The top-toolbar Export button opens settings for:
 
-- Uses the project's canvas resolution and FPS
-- Shows export progress in the toolbar
-- Downloads a file named after the current `.motion` project
-- Reports local server, FFmpeg, browser decoder, or asset failures clearly
+- MP4, WebM, or GIF format
+- Resolution and frame rate
+- MP4 quality
+- MP4 or WebM bitrate
 
-The current path evaluates each project frame in the browser, synchronizes seekable animated assets, uploads JPEG frames to the local Motionly server, and uses FFmpeg for H.264/AAC output.
+Motionly then:
+
+- Shows export progress in a centered dialog with a Cancel Export button
+- Opens the browser's Save dialog with a timestamped default file name
+- Reports FFmpeg, browser codec, decoder, or asset failures clearly
+
+MP4 export evaluates each project frame in the browser, synchronizes seekable animated assets, uploads JPEG frames to the local Motionly server, and uses FFmpeg for H.264/AAC output. WebM uses the browser's MediaRecorder support. GIF exports without audio.
 
 Project audio defined with an `audio` block is mixed at its persisted timeline offset. Audio embedded in video clips remains muted; use the project audio track when sound must export.
 
 Video, Lottie, and supported GIF assets seek before each captured frame. Animated SVG and GIF fallback use real-time runtimes, so Motionly restarts them and captures in real time while displaying an explicit editor warning about seeking and CSS-animation limitations.
 
-WebM and GIF code exists internally but is not a supported editor workflow yet.
-
 ## Near-Term Work
 
-- Visual 24, 30, and 60 FPS choices
-- Resolution and aspect-ratio presets
-- 720p, 1080p, 1440p, and 4K output choices
-- Clear cancellation and failure handling
-- WebM, GIF, PNG stills, and image-sequence export
+- PNG still and image-sequence export
 
 ## Export Rules
 

--- a/docs/guides/user-guide.mdx
+++ b/docs/guides/user-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Motionly user guide: edit, preview, and export"
-description: End-to-end guide to opening, editing, previewing, and exporting .motion projects in Motionly using tracks, clips, video assets, and MP4 output.
+description: End-to-end guide to opening, editing, previewing, and exporting .motion projects in Motionly using tracks, clips, video assets, and adjustable output settings.
 ---
 
 # Motionly User Guide
@@ -14,13 +14,13 @@ Motionly lets you open, edit, preview, save, and export `.motion` animations vis
 3. Change its visual properties and animation timing.
 4. Preview with Play/Pause or scrub to an exact frame.
 5. Save the updated `.motion` project.
-6. Export MP4 when the animation is ready.
+6. Export MP4, WebM, or GIF when the animation is ready.
 
 ## Top Toolbar
 
 - Open loads a `.motion` file.
 - Save overwrites an opened file when the browser provides a file handle. New or fallback uploads use Save As.
-- Export MP4 renders the current project and downloads an MP4.
+- Export opens output settings, then the browser's Save dialog with a timestamped default file name.
 - The GitHub Star control opens the repository and displays its current star count.
 
 ## Preview
@@ -129,9 +129,11 @@ The visual editor currently exposes a small entrance set:
 
 Use `power3.out` as the default for restrained motion. Additional presets and scene transitions will be added only when they provide a distinct, reusable motion pattern.
 
-## MP4 Export
+## Export
 
-Motionly renders evaluated canvas frames at the project's resolution and FPS, sends them to the local FFmpeg export server, and mixes project audio at its timeline offset. Video, Lottie, and decoded GIF assets seek before each frame. Projects containing real-time animated SVG/GIF fallbacks export at wall-clock speed so their animation is preserved.
+Choose MP4, WebM, or GIF plus the output resolution and frame rate. MP4 also offers Low, Medium, High, or Very High quality and an adjustable bitrate; WebM uses the selected bitrate; GIF exports without audio.
+
+Motionly renders evaluated canvas frames using those settings. MP4 sends frames to the local FFmpeg export server and mixes project audio at its timeline offset. Video, Lottie, and decoded GIF assets seek before each frame. Projects containing real-time animated SVG/GIF fallbacks export at wall-clock speed so their animation is preserved. The centered progress dialog includes Cancel Export.
 
 ## `.motion` Source
 

--- a/src/assets/mp4-video.ts
+++ b/src/assets/mp4-video.ts
@@ -104,7 +104,7 @@ export class Mp4FrameSource {
     const target = Math.max(0, time) * 1_000_000;
     if (this.lastTime < 0 || target < this.lastTime) this.restartAt(target);
     this.lastTime = target;
-    await this.decodeThrough(target + 250_000);
+    await this.decodeThrough(target, target + 250_000);
     this.frames.sort((left, right) => left.timestamp - right.timestamp);
     while (this.frames[0] && this.frames[0].timestamp <= target) {
       this.current?.close();
@@ -120,7 +120,7 @@ export class Mp4FrameSource {
   close(): void {
     this.current?.close();
     this.frames.splice(0).forEach((frame) => frame.close());
-    this.decoder.close();
+    if (this.decoder.state !== 'closed') this.decoder.close();
   }
 
   private restartAt(timestamp: number): void {
@@ -138,25 +138,40 @@ export class Mp4FrameSource {
     }
   }
 
-  private async decodeThrough(timestamp: number): Promise<void> {
-    let decoded = 0;
-    while (this.sampleIndex < this.samples.length) {
-      const sample = this.samples[this.sampleIndex]!;
-      const sampleTime = (sample.cts / sample.timescale) * 1_000_000;
-      if (decoded && sampleTime > timestamp) break;
-      if (!sample.data) throw new Error('MP4 sample data is unavailable');
-      this.decoder.decode(
-        new EncodedVideoChunk({
-          type: sample.is_sync ? 'key' : 'delta',
-          timestamp: sampleTime,
-          duration: (sample.duration / sample.timescale) * 1_000_000,
-          data: sample.data,
-        })
-      );
-      this.sampleIndex += 1;
-      decoded += 1;
+  private async decodeThrough(timestamp: number, preloadThrough: number): Promise<void> {
+    while (this.bufferedThrough() < timestamp) {
+      if (this.decoderError) break;
+      const queued = this.decoder.decodeQueueSize;
+      let decoded = 0;
+      while (this.sampleIndex < this.samples.length) {
+        const sample = this.samples[this.sampleIndex]!;
+        const sampleTime = (sample.cts / sample.timescale) * 1_000_000;
+        if (sampleTime > preloadThrough && (decoded || queued)) break;
+        if (!sample.data) throw new Error('MP4 sample data is unavailable');
+        this.decoder.decode(
+          new EncodedVideoChunk({
+            type: sample.is_sync ? 'key' : 'delta',
+            timestamp: sampleTime,
+            duration: (sample.duration / sample.timescale) * 1_000_000,
+            data: sample.data,
+          })
+        );
+        this.sampleIndex += 1;
+        decoded += 1;
+      }
+      if (this.bufferedThrough() >= timestamp) break;
+      if (this.sampleIndex === this.samples.length && this.decoder.decodeQueueSize === 0) {
+        await this.decoder.flush();
+        break;
+      }
+      // Let queued decoder work and output callbacks run without flush(), which
+      // would force the next sequential sample to be a key frame.
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
-    if (decoded) await this.decoder.flush();
     if (this.decoderError) throw this.decoderError;
+  }
+
+  private bufferedThrough(): number {
+    return Math.max(this.current?.timestamp ?? -1, this.frames.at(-1)?.timestamp ?? -1);
   }
 }

--- a/src/export/exporter.ts
+++ b/src/export/exporter.ts
@@ -40,7 +40,7 @@ function exportableAudioClips(scene: Scene, assets: Map<string, LoadedAsset>): E
   });
 }
 import type { EvaluatedScene } from '../types/scene';
-import type { ExportFormat, ExportSupport } from '../types/export';
+import type { ExportFormat, ExportQuality, ExportSupport } from '../types/export';
 import { Mp4FrameSource } from '../assets/mp4-video';
 
 const EXPORT_API = '/api/exports';
@@ -67,18 +67,46 @@ export async function exportVideo(options: {
   format: ExportFormat;
   height: number;
   fps: number;
+  quality?: ExportQuality;
+  bitrateMbps?: number;
+  signal?: AbortSignal;
   onProgress?: (progress: number) => void;
+  confirmFfmpegInstall?: () => boolean | Promise<boolean>;
+  onFfmpegInstallChange?: (installing: boolean, installed?: boolean) => void;
 }): Promise<Blob> {
-  const { scene, assets, format, height, fps, onProgress } = options;
+  const {
+    scene,
+    assets,
+    format,
+    height,
+    fps,
+    quality = 'high',
+    bitrateMbps = bitrateFor(height, fps) / 1_000_000,
+    signal,
+    onProgress,
+    confirmFfmpegInstall,
+    onFfmpegInstallChange,
+  } = options;
 
   if (format === 'gif') {
-    return exportGif({ scene, assets, height, fps, onProgress });
+    return exportGif({ scene, assets, height, fps, signal, onProgress });
   }
   if (format === 'mp4') {
-    return exportMp4Frames({ scene, assets, height, fps, onProgress });
+    return exportMp4Frames({
+      scene,
+      assets,
+      height,
+      fps,
+      quality,
+      bitrateMbps,
+      signal,
+      onProgress,
+      confirmFfmpegInstall,
+      onFfmpegInstallChange,
+    });
   }
 
-  return exportWebmRealtime({ scene, assets, height, fps, onProgress });
+  return exportWebmRealtime({ scene, assets, height, fps, bitrateMbps, signal, onProgress });
 }
 
 async function exportMp4Frames(options: {
@@ -86,9 +114,25 @@ async function exportMp4Frames(options: {
   assets: Map<string, LoadedAsset>;
   height: number;
   fps: number;
+  quality: ExportQuality;
+  bitrateMbps: number;
+  signal?: AbortSignal;
   onProgress?: (progress: number) => void;
+  confirmFfmpegInstall?: () => boolean | Promise<boolean>;
+  onFfmpegInstallChange?: (installing: boolean, installed?: boolean) => void;
 }): Promise<Blob> {
-  const { scene, assets, height, fps, onProgress } = options;
+  const {
+    scene,
+    assets,
+    height,
+    fps,
+    quality,
+    bitrateMbps,
+    signal,
+    onProgress,
+    confirmFfmpegInstall,
+    onFfmpegInstallChange,
+  } = options;
   const audioClips = exportableAudioClips(scene, assets);
   const width = Math.round((height * scene.canvas.width) / scene.canvas.height);
   const canvas = document.createElement('canvas');
@@ -97,16 +141,23 @@ async function exportMp4Frames(options: {
   const renderer = new CanvasRenderer(canvas);
   const scaledScene = scaleScene(scene, width, height);
   const totalFrames = frameCount(scaledScene.canvas.duration, fps);
+  throwIfAborted(signal);
+  if (!(await ensureFfmpeg(confirmFfmpegInstall, onFfmpegInstallChange, signal))) {
+    throw new DOMException('MP4 export cancelled', 'AbortError');
+  }
 
   const job = await requestJson<{ id: string }>(EXPORT_API, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
+    signal,
     body: JSON.stringify({
       width,
       height,
       fps,
       duration: scaledScene.canvas.duration,
       totalFrames,
+      quality,
+      bitrateMbps,
       audioClips: audioClips.map(({ clip }) => ({
         start: clip.start,
         duration: clip.duration,
@@ -118,30 +169,31 @@ async function exportMp4Frames(options: {
       })),
     }),
   });
-  const decoded = await prepareDecodedVideoAssets(assets);
-
+  onProgress?.(0.02);
+  let decoded: Awaited<ReturnType<typeof prepareDecodedVideoAssets>> | null = null;
   try {
+    decoded = await prepareDecodedVideoAssets(assets, signal);
+    onProgress?.(0.05);
     const realtime = hasRealtimeOnlyAssets(decoded.assets);
     if (realtime) await resetRealtimeAssets(decoded.assets);
     const startedAt = performance.now();
     let uploads: Promise<void>[] = [];
-    let uploadedFrames = 0;
     for (let frame = 0; frame < totalFrames; frame += 1) {
+      throwIfAborted(signal);
       if (realtime) await waitForFrame(startedAt, frame, fps);
       const evaluated = evaluateScene(scaledScene, frame / fps);
       await renderDecodedVideos(evaluated, decoded.sources);
       await synchronizeAnimatedAssets(evaluated, decoded.assets, { playing: false, exact: true });
       renderer.render(evaluated, decoded.assets);
-      const image = await canvasToJpeg(canvas);
+      const image = await canvasToJpeg(canvas, quality);
+      onProgress?.(0.05 + ((frame + 1) / totalFrames) * 0.7);
       uploads.push(
         request(`${EXPORT_API}/${job.id}/frames/${frame}`, {
           method: 'PUT',
           headers: { 'content-type': 'image/jpeg' },
+          signal,
           body: image,
-        }).then(() => {
-          uploadedFrames += 1;
-          onProgress?.((uploadedFrames / totalFrames) * 0.8);
-        })
+        }).then(() => undefined)
       );
       if (uploads.length === 4) {
         await Promise.all(uploads);
@@ -150,10 +202,11 @@ async function exportMp4Frames(options: {
       if (frame % 4 === 0) await wait(0);
     }
     await Promise.all(uploads);
+    onProgress?.(0.8);
 
     await Promise.all(
       audioClips.map(async ({ url }, index) => {
-        const audioResponse = await fetch(url);
+        const audioResponse = await fetch(url, { signal });
         if (!audioResponse.ok) {
           throw new Error(`Could not load audio (${audioResponse.status})`);
         }
@@ -162,13 +215,14 @@ async function exportMp4Frames(options: {
           headers: {
             'content-type': audioResponse.headers.get('content-type') ?? 'application/octet-stream',
           },
+          signal,
           body: await audioResponse.blob(),
         });
       })
     );
 
     onProgress?.(0.85);
-    const response = await request(`${EXPORT_API}/${job.id}/finish`, { method: 'POST' });
+    const response = await request(`${EXPORT_API}/${job.id}/finish`, { method: 'POST', signal });
     const video = await response.blob();
     onProgress?.(1);
     return video;
@@ -176,7 +230,52 @@ async function exportMp4Frames(options: {
     await fetch(`${EXPORT_API}/${job.id}`, { method: 'DELETE' }).catch(() => undefined);
     throw error;
   } finally {
-    decoded.sources.forEach((source) => source.close());
+    decoded?.sources.forEach((source) => source.close());
+  }
+}
+
+export async function ensureFfmpeg(
+  confirmInstall?: () => boolean | Promise<boolean>,
+  onInstallChange?: (installing: boolean, installed?: boolean) => void,
+  signal?: AbortSignal
+): Promise<boolean> {
+  let status: Response;
+  try {
+    status = await fetch(`${EXPORT_API}/ffmpeg`, { cache: 'no-store', signal });
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    throw new Error('MP4 export requires the local Motionly server', { cause: error });
+  }
+  if (status.ok) return true;
+  if (status.status !== 503) {
+    const message = (await status.text()).trim();
+    throw new Error(message || 'Could not check FFmpeg availability');
+  }
+  if (!confirmInstall) {
+    throw new Error('MP4 export requires FFmpeg, but ffmpeg was not found on PATH');
+  }
+  if (!(await confirmInstall())) {
+    return false;
+  }
+  onInstallChange?.(true);
+  let installed = false;
+  try {
+    const installation = await fetch(`${EXPORT_API}/ffmpeg`, {
+      method: 'POST',
+      headers: { 'x-motionly-action': 'install-ffmpeg' },
+      signal,
+    });
+    if (!installation.ok || installation.status === 202) {
+      const message = (await installation.text()).trim();
+      throw new Error(
+        message ||
+          'FFmpeg installation failed. Install FFmpeg manually, add ffmpeg to PATH, then restart Motionly.'
+      );
+    }
+    installed = true;
+    return true;
+  } finally {
+    onInstallChange?.(false, installed);
   }
 }
 
@@ -185,11 +284,13 @@ async function exportWebmRealtime(options: {
   assets: Map<string, LoadedAsset>;
   height: number;
   fps: number;
+  bitrateMbps: number;
+  signal?: AbortSignal;
   onProgress?: (progress: number) => void;
 }): Promise<Blob> {
-  const { scene, assets, height, fps, onProgress } = options;
+  const { scene, assets, height, fps, bitrateMbps, signal, onProgress } = options;
   const audioClips = exportableAudioClips(scene, assets);
-  const captureFps = Math.min(fps, 30);
+  const captureFps = fps;
   const mimeType = selectWebmMimeType();
   if (!mimeType) throw new Error('WEBM export is not supported by this browser');
 
@@ -200,10 +301,11 @@ async function exportWebmRealtime(options: {
   const renderer = new CanvasRenderer(canvas);
   const scaledScene = scaleScene(scene, width, height);
   const stream = canvas.captureStream(captureFps);
-  const audio = audioClips.length ? await attachAudio(stream, audioClips) : null;
+  throwIfAborted(signal);
+  const audio = audioClips.length ? await attachAudio(stream, audioClips, signal) : null;
   const recorder = new MediaRecorder(stream, {
     mimeType,
-    videoBitsPerSecond: bitrateFor(height, captureFps),
+    videoBitsPerSecond: Math.round(bitrateMbps * 1_000_000),
   });
   const chunks: Blob[] = [];
   recorder.ondataavailable = (event: BlobEvent) => {
@@ -227,6 +329,7 @@ async function exportWebmRealtime(options: {
       scene: scaledScene,
       assets,
       fps: captureFps,
+      signal,
       onProgress,
     });
     recorder.stop();
@@ -243,14 +346,18 @@ async function exportWebmRealtime(options: {
  * Schedule every audio clip into one stream: each source is trimmed, retimed,
  * levelled and faded on its own gain node, then started at its clip time.
  */
-async function attachAudio(stream: MediaStream, clips: readonly ExportAudioClip[]) {
+async function attachAudio(
+  stream: MediaStream,
+  clips: readonly ExportAudioClip[],
+  signal?: AbortSignal
+) {
   const context = new AudioContext();
   try {
     await context.resume();
     const destination = context.createMediaStreamDestination();
     const buffers = await Promise.all(
       clips.map(async ({ url }) => {
-        const response = await fetch(url);
+        const response = await fetch(url, { signal });
         if (!response.ok) throw new Error(`Could not load audio (${response.status})`);
         return context.decodeAudioData(await response.arrayBuffer());
       })
@@ -308,9 +415,10 @@ async function exportGif(options: {
   assets: Map<string, LoadedAsset>;
   height: number;
   fps: number;
+  signal?: AbortSignal;
   onProgress?: (progress: number) => void;
 }): Promise<Blob> {
-  const { scene, assets, height, fps, onProgress } = options;
+  const { scene, assets, height, fps, signal, onProgress } = options;
   const width = Math.round((height * scene.canvas.width) / scene.canvas.height);
   const canvas = document.createElement('canvas');
   canvas.width = width;
@@ -319,13 +427,14 @@ async function exportGif(options: {
   const scaledScene = scaleScene(scene, width, height);
   const encoder = new GifEncoder(width, height, 1000 / fps);
   const totalFrames = frameCount(scaledScene.canvas.duration, fps);
-  const decoded = await prepareDecodedVideoAssets(assets);
+  const decoded = await prepareDecodedVideoAssets(assets, signal);
   try {
     const realtime = hasRealtimeOnlyAssets(decoded.assets);
     if (realtime) await resetRealtimeAssets(decoded.assets);
     const startedAt = performance.now();
 
     for (let frame = 0; frame < totalFrames; frame += 1) {
+      throwIfAborted(signal);
       if (realtime) await waitForFrame(startedAt, frame, fps);
       const time = frame / fps;
       const evaluated = evaluateScene(scaledScene, time);
@@ -344,11 +453,12 @@ async function exportGif(options: {
   return encoder.finish();
 }
 
-async function prepareDecodedVideoAssets(assets: Map<string, LoadedAsset>) {
+async function prepareDecodedVideoAssets(assets: Map<string, LoadedAsset>, signal?: AbortSignal) {
   const prepared = new Map(assets);
   const sources = new Map<string, Mp4FrameSource>();
   if (typeof VideoDecoder === 'undefined') return { assets: prepared, sources };
   for (const [name, asset] of assets) {
+    throwIfAborted(signal);
     if (!asset.motionlyMp4) continue;
     const source = await Mp4FrameSource.create(asset.motionlyMp4);
     const canvas = source.canvas as unknown as LoadedAsset;
@@ -387,13 +497,15 @@ async function renderTimelineRealtime(options: {
   scene: Scene;
   assets: Map<string, LoadedAsset>;
   fps: number;
+  signal?: AbortSignal;
   onProgress?: (progress: number) => void;
 }): Promise<void> {
-  const { renderer, scene, assets, fps, onProgress } = options;
+  const { renderer, scene, assets, fps, signal, onProgress } = options;
   const startedAt = performance.now();
   let previousFrame = -1;
 
   while (true) {
+    throwIfAborted(signal);
     await nextAnimationFrame();
     const elapsed = Math.min(scene.canvas.duration, (performance.now() - startedAt) / 1000);
     const frame = Math.min(frameCount(scene.canvas.duration, fps) - 1, Math.floor(elapsed * fps));
@@ -418,7 +530,7 @@ async function waitForFrame(startedAt: number, frame: number, fps: number): Prom
   if (delay > 0) await wait(delay);
 }
 
-function canvasToJpeg(canvas: HTMLCanvasElement): Promise<Blob> {
+function canvasToJpeg(canvas: HTMLCanvasElement, quality: ExportQuality): Promise<Blob> {
   return new Promise((resolve, reject) => {
     canvas.toBlob(
       (blob) => {
@@ -426,7 +538,7 @@ function canvasToJpeg(canvas: HTMLCanvasElement): Promise<Blob> {
         else reject(new Error('Could not capture an export frame'));
       },
       'image/jpeg',
-      0.95
+      quality === 'low' ? 0.8 : quality === 'medium' ? 0.88 : quality === 'high' ? 0.94 : 0.98
     );
   });
 }
@@ -435,14 +547,25 @@ async function request(url: string, init: RequestInit): Promise<Response> {
   let response: Response;
   try {
     response = await fetch(url, init);
-  } catch {
-    throw new Error('MP4 export requires the local Motionly server with ffmpeg installed');
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    throw new Error('MP4 export requires the local Motionly server with ffmpeg installed', {
+      cause: error,
+    });
   }
   if (!response.ok) {
     const message = (await response.text()).trim();
     throw new Error(message || `MP4 export failed (${response.status})`);
   }
   return response;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException('Export cancelled', 'AbortError');
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
 }
 
 async function requestJson<T>(url: string, init: RequestInit): Promise<T> {

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -10,6 +10,15 @@ import type { Scene, EvaluatedScene } from './scene';
  * Supported export formats
  */
 export type ExportFormat = 'mp4' | 'webm' | 'gif';
+export type ExportQuality = 'low' | 'medium' | 'high' | 'very-high';
+
+export interface VideoExportSettings {
+  format: ExportFormat;
+  height: number;
+  fps: number;
+  quality: ExportQuality;
+  bitrateMbps: number;
+}
 
 /**
  * Export format support information

--- a/src/ui/MotionlyApp.svelte
+++ b/src/ui/MotionlyApp.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { Download, FileText, FolderOpen, Save, Star } from 'lucide-svelte';
+  import { Download, FileText, FolderOpen, LoaderCircle, Save, Star, X } from 'lucide-svelte';
   import { appUrl } from '../app/routing';
   import MotionEditor from './components/MotionEditor.svelte';
+  import type { ExportSupport, VideoExportSettings } from '../types/export';
 
   const logoUrl = appUrl('logo.svg');
   const githubIconUrl = appUrl('github.svg');
+  // ponytail: localStorage is enough for source drafts; move to IndexedDB if projects exceed its quota.
+  const autoSaveKey = 'motionly:auto-save';
 
   type MotionFileHandle = {
     name: string;
     getFile(): Promise<File>;
-    createWritable(): Promise<{ write(data: string): Promise<void>; close(): Promise<void> }>;
+    createWritable(): Promise<{ write(data: string | Blob): Promise<void>; close(): Promise<void> }>;
   };
 
   type FilePickerWindow = Window & {
@@ -19,7 +22,12 @@
   };
 
   type MotionEditorHandle = {
-    exportMp4(filename?: string, onProgress?: (progress: number) => void): Promise<void>;
+    getExportInfo(): { width: number; height: number; fps: number; support: ExportSupport };
+    exportProject(
+      settings: VideoExportSettings,
+      onProgress?: (progress: number) => void,
+      signal?: AbortSignal
+    ): Promise<Blob | null>;
   };
 
   const fallbackMotion = `canvas {
@@ -54,9 +62,23 @@ animate title {
   easing power3.out
 }`;
 
-  let motionCode = fallbackMotion;
+  function loadAutoSave(): { code: string; name: string } | null {
+    try {
+      const saved = JSON.parse(localStorage.getItem(autoSaveKey) ?? 'null') as {
+        code?: unknown;
+        name?: unknown;
+      } | null;
+      return saved && typeof saved.code === 'string' && typeof saved.name === 'string'
+        ? { code: saved.code, name: saved.name }
+        : null;
+    } catch {
+      return null;
+    }
+  }
 
-  let currentFile = 'untitled.motion';
+  const autoSave = loadAutoSave();
+  let motionCode = autoSave?.code ?? fallbackMotion;
+  let currentFile = autoSave?.name ?? 'untitled.motion';
   let fileInput: HTMLInputElement;
   let fileHandle: MotionFileHandle | null = null;
   let serverBacked = false;
@@ -65,6 +87,24 @@ animate title {
   let editor: MotionEditorHandle | undefined;
   let isExporting = false;
   let exportProgress = 0;
+  let exportSuccess = '';
+  let exportSuccessTimer: ReturnType<typeof setTimeout> | null = null;
+  let showExportSettings = false;
+  let isCancellingExport = false;
+  let exportController: AbortController | null = null;
+  let exportInfo = {
+    width: 1920,
+    height: 1080,
+    fps: 60,
+    support: { mp4: true, webm: false, gif: true },
+  };
+  let exportSettings: VideoExportSettings = {
+    format: 'mp4',
+    height: 1080,
+    fps: 60,
+    quality: 'high',
+    bitrateMbps: 10,
+  };
   let starCount: number | null = null;
 
   onMount(() => {
@@ -72,10 +112,18 @@ animate title {
     void loadStarCount();
     return () => {
       if (saveTimer) clearTimeout(saveTimer);
+      if (exportSuccessTimer) clearTimeout(exportSuccessTimer);
     };
   });
 
-  $: if (fileHandle) scheduleAutoSave(motionCode);
+  $: if (fileHandle || serverBacked) scheduleAutoSave(motionCode);
+  $: {
+    try {
+      localStorage.setItem(autoSaveKey, JSON.stringify({ code: motionCode, name: currentFile }));
+    } catch {
+      // Keep editing when browser storage is unavailable or full.
+    }
+  }
 
   async function loadInitialProject() {
     try {
@@ -89,9 +137,6 @@ animate title {
     } catch (error) {
       console.warn(error);
     }
-    
-    // Start with simple fallback motion
-    motionCode = fallbackMotion;
   }
 
   async function handleOpen() {
@@ -122,12 +167,7 @@ animate title {
       return;
     }
     if (serverBacked) {
-      const response = await fetch('/api/motion-project', {
-        method: 'PUT',
-        headers: { 'content-type': 'text/plain;charset=utf-8' },
-        body: motionCode,
-      });
-      if (!response.ok) throw new Error(`Could not save ${currentFile} (${response.status})`);
+      await writeServerProject(motionCode);
       return;
     }
     const picker = (window as FilePickerWindow).showSaveFilePicker;
@@ -165,12 +205,14 @@ animate title {
   }
 
   function scheduleAutoSave(source: string) {
-    if (!fileHandle) return;
+    if (!fileHandle && !serverBacked) return;
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       const handle = fileHandle;
-      if (!handle) return;
-      writeQueue = writeQueue.then(() => writeFile(handle, source)).catch(console.error);
+      if (!handle && !serverBacked) return;
+      writeQueue = writeQueue
+        .then(() => (handle ? writeFile(handle, source) : writeServerProject(source)))
+        .catch(console.error);
     }, 250);
   }
 
@@ -180,15 +222,135 @@ animate title {
     await writable.close();
   }
 
+  async function writeServerProject(source: string) {
+    const response = await fetch('/api/motion-project', {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain;charset=utf-8' },
+      body: source,
+    });
+    if (!response.ok) throw new Error(`Could not save ${currentFile} (${response.status})`);
+  }
+
+  function openExportSettings() {
+    if (!editor || isExporting) return;
+    exportInfo = editor.getExportInfo();
+    exportSettings = {
+      format: 'mp4',
+      height: exportInfo.height,
+      fps: exportInfo.fps,
+      quality: 'high',
+      bitrateMbps: defaultBitrate(exportInfo.height, exportInfo.fps),
+    };
+    showExportSettings = true;
+  }
+
+  function closeExportSettings() {
+    showExportSettings = false;
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (showExportSettings && event.key === 'Escape') {
+      event.preventDefault();
+      closeExportSettings();
+    }
+  }
+
+  function defaultBitrate(height: number, fps: number): number {
+    const base = height >= 2160 ? 28 : height >= 1440 ? 18 : height >= 1080 ? 10 : 5;
+    return Math.max(1, Math.round(base * (fps / 60)));
+  }
+
+  function exportWidth(height: number): number {
+    return Math.round((height * exportInfo.width) / exportInfo.height);
+  }
+
+  function resolutionOptions(): number[] {
+    return [...new Set([480, 720, 1080, 1440, 2160, exportInfo.height])].sort((a, b) => a - b);
+  }
+
+  function frameRateOptions(): number[] {
+    return [...new Set([24, 25, 30, 50, 60, exportInfo.fps])].sort((a, b) => a - b);
+  }
+
+  function bitrateOptions(): number[] {
+    return [...new Set([2, 5, 10, 20, 30, 50, 100, exportSettings.bitrateMbps])].sort((a, b) => a - b);
+  }
+
+  function cancelExport() {
+    if (!exportController || isCancellingExport) return;
+    isCancellingExport = true;
+    exportController.abort();
+  }
+
+  function showExportSuccess() {
+    if (exportSuccessTimer) clearTimeout(exportSuccessTimer);
+    exportSuccess = 'Export successful.';
+    exportSuccessTimer = setTimeout(() => (exportSuccess = ''), 1000);
+  }
+
   async function handleExport() {
     if (!editor || isExporting) return;
+    const settings = {
+      ...exportSettings,
+      height: Math.max(144, Math.min(4320, Number(exportSettings.height) || exportInfo.height)),
+      fps: Math.max(1, Math.min(120, Number(exportSettings.fps) || exportInfo.fps)),
+      bitrateMbps: Math.max(0.5, Math.min(200, Number(exportSettings.bitrateMbps) || 10)),
+    };
+    showExportSettings = false;
+    const project = currentFile.replace(/\.motion$/i, '') || 'project';
+    const now = new Date();
+    const pad = (value: number) => String(value).padStart(2, '0');
+    const format = {
+      mp4: { extension: 'mp4', description: 'MP4 video', mime: 'video/mp4' },
+      webm: { extension: 'webm', description: 'WebM video', mime: 'video/webm' },
+      gif: { extension: 'gif', description: 'Animated GIF', mime: 'image/gif' },
+    }[settings.format];
+    const filename =
+      `${project}_${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}` +
+      `_${pad(now.getHours())}${pad(now.getMinutes())}.${format.extension}`;
+    const picker = (window as FilePickerWindow).showSaveFilePicker;
+    let outputHandle: MotionFileHandle | null = null;
+    if (picker) {
+      try {
+        outputHandle = await picker.call(window, {
+          suggestedName: filename,
+          types: [{ description: format.description, accept: { [format.mime]: [`.${format.extension}`] } }],
+        });
+      } catch (error) {
+        if ((error as DOMException).name !== 'AbortError') console.error(error);
+        return;
+      }
+    }
+
+    exportController = new AbortController();
     isExporting = true;
+    isCancellingExport = false;
     exportProgress = 0;
     try {
-      const filename = currentFile.replace(/\.motion$/i, '') || 'motionly';
-      await editor.exportMp4(`${filename}.mp4`, (progress) => (exportProgress = progress));
+      const video = await editor.exportProject(
+        settings,
+        (progress) => (exportProgress = progress),
+        exportController.signal
+      );
+      if (!video || exportController.signal.aborted) return;
+      exportProgress = 1;
+      if (outputHandle) {
+        const writable = await outputHandle.createWritable();
+        await writable.write(video);
+        await writable.close();
+      } else {
+        const url = URL.createObjectURL(video);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        link.click();
+        URL.revokeObjectURL(url);
+      }
+      showExportSuccess();
     } finally {
+      exportController = null;
       isExporting = false;
+      isCancellingExport = false;
     }
   }
 
@@ -207,6 +369,8 @@ animate title {
     return new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
   }
 </script>
+
+<svelte:window on:keydown={handleWindowKeydown} />
 
 <div class="app">
   <!-- Top Bar -->
@@ -253,9 +417,13 @@ animate title {
         <Save size={18} />
         <span class="action-label">Save</span>
       </button>
-      <button on:click={handleExport} class="btn export-action" disabled={isExporting} title="Export MP4">
-        <Download size={18} />
-        <span class="action-label">{isExporting ? `Exporting ${Math.round(exportProgress * 100)}%` : 'Export MP4'}</span>
+      <button on:click={openExportSettings} class="btn export-action" disabled={isExporting || showExportSettings} title="Export">
+        {#if isExporting}
+          <span class="export-spinner" aria-hidden="true"><LoaderCircle size={18} /></span>
+        {:else}
+          <Download size={18} />
+        {/if}
+        <span class="action-label">{isExporting ? `Exporting ${Math.round(exportProgress * 100)}%` : 'Export'}</span>
       </button>
       <a
         class="btn github-btn"
@@ -294,6 +462,116 @@ animate title {
 
   <!-- Editor -->
   <MotionEditor bind:this={editor} bind:code={motionCode} onSave={handleSave} {serverBacked} />
+
+  {#if showExportSettings}
+    <div class="export-settings-overlay">
+      <div class="export-settings-dialog" role="dialog" aria-modal="true" aria-labelledby="export-settings-title">
+        <div class="export-settings-header">
+          <div>
+            <h2 id="export-settings-title">Export Settings</h2>
+            <p>Choose the output settings before selecting where to save.</p>
+          </div>
+          <button type="button" on:click={closeExportSettings} aria-label="Close export settings">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div class="export-settings-grid">
+          <label>
+            <span>Export format</span>
+            <select id="export-format" bind:value={exportSettings.format}>
+              <option value="mp4">MP4</option>
+              <option value="webm" disabled={!exportInfo.support.webm}>WebM</option>
+              <option value="gif">GIF</option>
+            </select>
+          </label>
+
+          <label>
+            <span>Resolution</span>
+            <select id="export-resolution" bind:value={exportSettings.height}>
+              {#each resolutionOptions() as height}
+                <option value={height}>{exportWidth(height)} × {height}</option>
+              {/each}
+            </select>
+          </label>
+
+          <label>
+            <span>Frame rate</span>
+            <select id="export-fps" bind:value={exportSettings.fps}>
+              {#each frameRateOptions() as fps}
+                <option value={fps}>{fps} FPS</option>
+              {/each}
+            </select>
+          </label>
+
+          <label>
+            <span>Video quality</span>
+            <select id="export-quality" bind:value={exportSettings.quality} disabled={exportSettings.format !== 'mp4'}>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="very-high">Very High</option>
+            </select>
+          </label>
+
+          <label>
+            <span>Bitrate</span>
+            <select
+              id="export-bitrate"
+              bind:value={exportSettings.bitrateMbps}
+              disabled={exportSettings.format === 'gif'}
+            >
+              {#each bitrateOptions() as bitrate}
+                <option value={bitrate}>{bitrate} Mbps</option>
+              {/each}
+            </select>
+          </label>
+        </div>
+
+        {#if exportSettings.format === 'gif'}
+          <p class="export-settings-note">GIF does not use video quality or bitrate.</p>
+        {:else if exportSettings.format === 'webm'}
+          <p class="export-settings-note">WebM quality is controlled by bitrate.</p>
+        {/if}
+
+        <div class="export-settings-footer">
+          <button type="button" class="export-settings-cancel" on:click={closeExportSettings}>Cancel</button>
+          <button type="button" class="export-settings-confirm" on:click={handleExport}>Choose Save Location</button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  {#if isExporting}
+    <div class="export-progress-overlay">
+      <div class="export-progress-card" role="status" aria-live="polite">
+        <span class="export-progress-spinner" aria-hidden="true"><LoaderCircle size={30} /></span>
+        <h2>Exporting {exportSettings.format.toUpperCase()}</h2>
+        <p>{Math.round(exportProgress * 100)}% complete</p>
+        <div
+          class="export-progress-track"
+          role="progressbar"
+          aria-label={`${exportSettings.format.toUpperCase()} export progress`}
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow={Math.round(exportProgress * 100)}
+        >
+          <span style={`width: ${Math.round(exportProgress * 100)}%`}></span>
+        </div>
+        <button type="button" class="export-cancel-button" on:click={cancelExport} disabled={isCancellingExport}>
+          {isCancellingExport ? 'Cancelling…' : 'Cancel Export'}
+        </button>
+      </div>
+    </div>
+  {/if}
+
+  {#if exportSuccess}
+    <div class="export-progress-overlay export-success-overlay">
+      <div class="export-progress-card export-success-card" role="status" aria-live="polite">
+        <h2>{exportSuccess}</h2>
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -440,6 +718,264 @@ animate title {
     justify-content: center;
   }
 
+  .export-spinner {
+    display: inline-flex;
+    animation: export-spin 0.8s linear infinite;
+  }
+
+  .export-settings-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+  }
+
+  .export-settings-dialog {
+    width: min(520px, calc(100vw - 40px));
+    max-height: calc(100vh - 40px);
+    overflow: auto;
+    border: 1px solid #2a2d33;
+    border-radius: 12px;
+    background: #17191c;
+    color: #e4e6ea;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  }
+
+  .export-settings-header,
+  .export-settings-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 20px;
+  }
+
+  .export-settings-header {
+    border-bottom: 1px solid #2a2d33;
+  }
+
+  .export-settings-header h2,
+  .export-settings-header p {
+    margin: 0;
+  }
+
+  .export-settings-header h2 {
+    font-size: 16px;
+  }
+
+  .export-settings-header p {
+    margin-top: 5px;
+    color: #9ca3af;
+    font-size: 12px;
+  }
+
+  .export-settings-header button {
+    display: grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: #9ca3af;
+    cursor: pointer;
+  }
+
+  .export-settings-header button:hover {
+    background: #24262a;
+    color: #fff;
+  }
+
+  .export-settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    padding: 20px;
+  }
+
+  .export-settings-grid label > span {
+    display: block;
+    margin-bottom: 7px;
+    color: #aeb3bb;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .export-settings-grid select {
+    width: 100%;
+    height: 38px;
+    box-sizing: border-box;
+    border: 1px solid #343840;
+    border-radius: 6px;
+    outline: none;
+    background: #111214;
+    color: #e4e6ea;
+    font: inherit;
+  }
+
+  .export-settings-grid select {
+    appearance: none;
+    padding: 0 36px 0 12px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+  }
+
+  .export-settings-grid select:focus {
+    border-color: #0a84ff;
+  }
+
+  .export-settings-grid select:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .export-settings-note {
+    margin: -4px 20px 16px;
+    color: #8e939b;
+    font-size: 12px;
+  }
+
+  .export-settings-footer {
+    justify-content: flex-end;
+    border-top: 1px solid #2a2d33;
+    background: #111214;
+  }
+
+  .export-settings-footer button,
+  .export-cancel-button {
+    padding: 8px 14px;
+    border: 1px solid #343840;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .export-settings-cancel,
+  .export-cancel-button {
+    background: transparent;
+    color: #d8dce2;
+  }
+
+  .export-settings-confirm {
+    background: #ef4444;
+    border-color: #ef4444 !important;
+    color: #fff;
+  }
+
+  .export-progress-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 900;
+    display: grid;
+    place-items: center;
+    background: rgba(0, 0, 0, 0.68);
+    backdrop-filter: blur(4px);
+  }
+
+  .export-success-overlay {
+    z-index: 1200;
+  }
+
+  .export-success-card {
+    padding: 24px;
+    border: 1px solid rgba(74, 222, 128, 0.4);
+    color: #dcfce7;
+    animation: export-toast-in 0.18s ease-out;
+  }
+
+  .export-success-card h2 {
+    margin: 0;
+  }
+
+  .export-progress-card {
+    width: min(360px, calc(100vw - 40px));
+    box-sizing: border-box;
+    padding: 28px;
+    border: 1px solid #2a2d33;
+    border-radius: 12px;
+    background: #17191c;
+    color: #e4e6ea;
+    text-align: center;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  }
+
+  .export-progress-spinner {
+    display: inline-flex;
+    color: #ef4444;
+    animation: export-spin 0.55s linear infinite;
+  }
+
+  .export-progress-card h2 {
+    margin: 14px 0 5px;
+    font-size: 17px;
+  }
+
+  .export-progress-card p {
+    margin: 0 0 18px;
+    color: #9ca3af;
+    font-size: 13px;
+  }
+
+  .export-progress-track {
+    position: relative;
+    height: 6px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #2a2d33;
+  }
+
+  .export-progress-track::after {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.24) 50%, transparent 100%);
+    content: '';
+    transform: translateX(-100%);
+    animation: export-shimmer 0.75s ease-in-out infinite;
+  }
+
+  .export-progress-track span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: #ef4444;
+    transition: width 0.15s ease;
+  }
+
+  .export-cancel-button {
+    margin-top: 20px;
+  }
+
+  .export-cancel-button:disabled {
+    cursor: wait;
+    opacity: 0.6;
+  }
+
+  @keyframes export-spin {
+    to { transform: rotate(360deg); }
+  }
+
+  @keyframes export-shimmer {
+    to { transform: translateX(100%); }
+  }
+
+  @keyframes export-toast-in {
+    from { opacity: 0; transform: translateY(-6px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .export-progress-spinner,
+    .export-progress-track::after,
+    .export-success-card {
+      animation: none;
+    }
+  }
+
   .btn-primary {
     background: #0a84ff;
     border-color: #0a84ff;
@@ -528,6 +1064,10 @@ animate title {
       width: auto;
       min-width: 58px;
       padding: 0 8px;
+    }
+
+    .export-settings-grid {
+      grid-template-columns: 1fr;
     }
   }
 

--- a/src/ui/components/MotionEditor.svelte
+++ b/src/ui/components/MotionEditor.svelte
@@ -19,7 +19,8 @@
   import { decomposeSvg } from '../../assets/svg-decomposition';
   import type { AssetIdentity } from '../../assets/asset-resolution';
   import { CanvasRenderer, hiddenMaskSourceIds } from '../../render/canvas-renderer';
-  import { canExport, exportVideo } from '../../export/exporter';
+  import { canExport, exportSupport, exportVideo } from '../../export/exporter';
+  import type { VideoExportSettings } from '../../types/export';
   import type { AnimationNode, CameraNode, ClipNode, ElementNode, ImportNode, ProgramNode, TrackNode } from '../../types/parser';
   import { serializeProgram } from '../../language/serializer';
   import type { Asset, Clip, Element, EvaluatedElement, EvaluatedScene, Scene, Track } from '../../types/scene';
@@ -164,7 +165,6 @@
   let audioEngine: AudioEngine | null = null;
   let timelineHeight = 230;
   let contentPanelWidth = 260;
-  let mp4Supported = false;
   let isExporting = false;
   let exportError = '';
   let assetError = '';
@@ -177,6 +177,8 @@
     | { kind: 'assets'; assets: Asset[]; usageCount: number }
     | { kind: 'text'; ids: string[] }
     | null = null;
+  let pendingFfmpegInstall: { resolve: (accepted: boolean) => void } | null = null;
+  let isInstallingFfmpeg = false;
   let previewAsset: AssetPreview | null = null;
   let videoRenderId = 0;
   let isDraggingUpload = false;
@@ -207,7 +209,6 @@
 
 
   onMount(() => {
-    mp4Supported = canExport('mp4');
     audioEngine = new AudioEngine({
       source: (assetName) => assets.get(assetName)?.motionlySource,
     });
@@ -301,6 +302,8 @@
       audioEngine = null;
       if (deleteToastTimer) clearTimeout(deleteToastTimer);
       if (keyframeNoticeTimer) clearTimeout(keyframeNoticeTimer);
+      pendingFfmpegInstall?.resolve(false);
+      pendingFfmpegInstall = null;
       window.removeEventListener('keydown', handleKeyDown);
     };
   });
@@ -371,12 +374,23 @@
   }
 
   function cancelConfirmDialog() {
-    if (pendingDelete) pendingDelete = null;
+    if (isInstallingFfmpeg) return;
+    if (pendingFfmpegInstall) {
+      const { resolve } = pendingFfmpegInstall;
+      pendingFfmpegInstall = null;
+      resolve(false);
+    } else if (pendingDelete) pendingDelete = null;
     else cancelLoadPreset();
     showConfirmDialog = false;
   }
 
   function confirmDialog() {
+    if (pendingFfmpegInstall) {
+      const { resolve } = pendingFfmpegInstall;
+      isInstallingFfmpeg = true;
+      resolve(true);
+      return;
+    }
     if (!pendingDelete) return confirmLoadPreset();
     const deletion = pendingDelete;
     pendingDelete = null;
@@ -385,6 +399,22 @@
       for (const asset of deletion.assets) removeAssetNow(asset);
     } else {
       for (const id of deletion.ids) deleteElement(id);
+    }
+  }
+
+  function confirmFfmpegInstall(): Promise<boolean> {
+    showConfirmDialog = true;
+    return new Promise((resolve) => {
+      pendingFfmpegInstall = { resolve };
+    });
+  }
+
+  function handleFfmpegInstallChange(installing: boolean, installed = false) {
+    isInstallingFfmpeg = installing;
+    if (!installing) {
+      pendingFfmpegInstall = null;
+      showConfirmDialog = false;
+      if (installed) showKeyframeNotice('FFmpeg installed.', 1000);
     }
   }
 
@@ -888,41 +918,53 @@
   }
 
 
-  export async function exportMp4(
-    filename = 'motionly.mp4',
-    onProgress?: (progress: number) => void
-  ) {
-    if (!scene || isExporting) return;
-    if (!mp4Supported) {
-      exportError = 'MP4 export is not supported by this browser.';
-      return;
+  export function getExportInfo() {
+    return {
+      width: scene?.canvas.width ?? 1920,
+      height: scene?.canvas.height ?? 1080,
+      fps: scene?.canvas.fps ?? 60,
+      support: exportSupport(),
+    };
+  }
+
+  export async function exportProject(
+    settings: VideoExportSettings,
+    onProgress?: (progress: number) => void,
+    signal?: AbortSignal
+  ): Promise<Blob | null> {
+    if (!scene || isExporting) return null;
+    if (!canExport(settings.format)) {
+      exportError = `${settings.format.toUpperCase()} export is not supported by this browser.`;
+      return null;
     }
     if (!assetsReady) {
       exportError = 'Assets are still loading. Try export again in a moment.';
-      return;
+      return null;
     }
     pause();
     isExporting = true;
     exportError = '';
     try {
-      const blob = await exportVideo({
+      return await exportVideo({
         scene,
         assets,
-        format: 'mp4',
-        height: scene.canvas.height,
-        fps: scene.canvas.fps,
+        format: settings.format,
+        height: Math.max(144, Math.min(4320, Math.round(settings.height))),
+        fps: Math.max(1, Math.min(120, Math.round(settings.fps))),
+        quality: settings.quality,
+        bitrateMbps: Math.max(0.5, Math.min(200, settings.bitrateMbps)),
+        signal,
+        confirmFfmpegInstall,
+        onFfmpegInstallChange: handleFfmpegInstallChange,
         onProgress: (progress) => {
           onProgress?.(progress);
         },
       });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      link.click();
-      URL.revokeObjectURL(url);
     } catch (error) {
-      exportError = error instanceof Error ? error.message : String(error);
+      if ((error as DOMException).name !== 'AbortError') {
+        exportError = error instanceof Error ? error.message : String(error);
+      }
+      return null;
     } finally {
       isExporting = false;
     }
@@ -2732,13 +2774,13 @@
     return false;
   }
 
-  function showKeyframeNotice(message: string) {
+  function showKeyframeNotice(message: string, duration = 1600) {
     if (keyframeNoticeTimer) clearTimeout(keyframeNoticeTimer);
     keyframeNotice = message;
     keyframeNoticeTimer = setTimeout(() => {
       keyframeNotice = '';
       keyframeNoticeTimer = null;
-    }, 1600);
+    }, duration);
   }
 
   function keyframeEasingAt(offset: number | null): string {
@@ -3291,19 +3333,28 @@
   {deleteToast}
   {keyframeNotice}
   {showConfirmDialog}
-  dialogTitle={pendingDelete?.kind === 'assets'
+  dialogTitle={pendingFfmpegInstall
+    ? 'Install FFmpeg?'
+    : pendingDelete?.kind === 'assets'
     ? 'Delete Asset'
     : pendingDelete?.kind === 'text'
       ? 'Delete Text'
       : 'Load Preset'}
-  dialogMessage={pendingDelete?.kind === 'assets'
+  dialogMessage={pendingFfmpegInstall
+    ? 'MP4 export requires FFmpeg, but it is not installed.'
+    : pendingDelete?.kind === 'assets'
     ? pendingDelete.assets.length === 1
       ? `${pendingDelete.assets[0].name} is used ${pendingDelete.usageCount} time${pendingDelete.usageCount === 1 ? '' : 's'}. Delete it and its timeline items?`
       : `Delete ${pendingDelete.assets.length} selected assets and their timeline items?`
     : pendingDelete?.kind === 'text'
       ? `Delete ${pendingDelete.ids.length === 1 ? pendingDelete.ids[0] : `${pendingDelete.ids.length} selected text layers`}?`
       : 'Loading this preset will replace your current project and assets. Continue?'}
-  dialogConfirmLabel={pendingDelete ? 'Delete' : 'Load Preset'}
+  dialogConfirmLabel={pendingFfmpegInstall
+    ? 'Install FFmpeg'
+    : pendingDelete
+        ? 'Delete'
+        : 'Load Preset'}
+  dialogBusy={isInstallingFfmpeg}
   onUndoDelete={undoDelete}
   onCancelDialog={cancelConfirmDialog}
   onConfirmDialog={confirmDialog}

--- a/src/ui/components/motion-editor/EditorFeedback.svelte
+++ b/src/ui/components/motion-editor/EditorFeedback.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './editor-feedback.css';
-  import { X } from 'lucide-svelte';
+  import { LoaderCircle, X } from 'lucide-svelte';
 
   export let deleteToast: string;
   export let keyframeNotice: string;
@@ -8,12 +8,13 @@
   export let dialogTitle: string;
   export let dialogMessage: string;
   export let dialogConfirmLabel: string;
+  export let dialogBusy = false;
   export let onUndoDelete: () => void;
   export let onCancelDialog: () => void;
   export let onConfirmDialog: () => void | Promise<void>;
 
   function handleWindowKeydown(event: KeyboardEvent) {
-    if (showConfirmDialog && event.key === 'Escape') {
+    if (showConfirmDialog && !dialogBusy && event.key === 'Escape') {
       event.preventDefault();
       onCancelDialog();
     }
@@ -35,11 +36,11 @@
 {/if}
 
 {#if showConfirmDialog}
-  <div class="me-dialog-overlay" on:click={onCancelDialog} on:keydown={() => undefined} role="button" tabindex="-1">
-    <div class="me-dialog" on:click|stopPropagation on:keydown={(event) => event.key === 'Enter' && onConfirmDialog()} role="dialog" aria-labelledby="dialog-title" aria-modal="true" tabindex="0">
+  <div class="me-dialog-overlay" on:click={() => !dialogBusy && onCancelDialog()} on:keydown={() => undefined} role="button" tabindex="-1">
+    <div class="me-dialog" on:click|stopPropagation on:keydown={(event) => event.key === 'Enter' && !dialogBusy && onConfirmDialog()} role="dialog" aria-labelledby="dialog-title" aria-modal="true" aria-busy={dialogBusy} tabindex="0">
       <div class="me-dialog-header">
         <h3 id="dialog-title">{dialogTitle}</h3>
-        <button type="button" class="me-dialog-close" on:click={onCancelDialog} aria-label="Cancel">
+        <button type="button" class="me-dialog-close" on:click={onCancelDialog} aria-label="Cancel" disabled={dialogBusy}>
           <X size={18} />
         </button>
       </div>
@@ -47,8 +48,15 @@
         <p>{dialogMessage}</p>
       </div>
       <div class="me-dialog-footer">
-        <button type="button" class="me-dialog-btn me-secondary" on:click={onCancelDialog}>Cancel</button>
-        <button type="button" class="me-dialog-btn me-danger" on:click={onConfirmDialog}>{dialogConfirmLabel}</button>
+        <button type="button" class="me-dialog-btn me-secondary" on:click={onCancelDialog} disabled={dialogBusy}>Cancel</button>
+        <button type="button" class="me-dialog-btn me-danger" on:click={onConfirmDialog} disabled={dialogBusy}>
+          {#if dialogBusy}
+            <LoaderCircle class="me-dialog-spinner" size={15} aria-hidden="true" />
+            Installing…
+          {:else}
+            {dialogConfirmLabel}
+          {/if}
+        </button>
       </div>
     </div>
   </div>

--- a/src/ui/components/motion-editor/editor-feedback.css
+++ b/src/ui/components/motion-editor/editor-feedback.css
@@ -75,6 +75,9 @@
 }
 
 .motion-editor-scope .me-dialog-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   padding: 8px 16px;
   border: 1px solid #2a2d33;
   border-radius: 6px;
@@ -82,6 +85,22 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s ease;
+}
+
+.motion-editor-scope .me-dialog-btn:disabled,
+.motion-editor-scope .me-dialog-close:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.motion-editor-scope .me-dialog-spinner {
+  animation: me-spin 0.8s linear infinite;
+}
+
+@keyframes me-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .motion-editor-scope .me-dialog-btn.me-secondary {

--- a/tests/assets/video-assets.test.ts
+++ b/tests/assets/video-assets.test.ts
@@ -8,6 +8,7 @@ import {
   videoSourceTime,
   type LoadedAsset,
 } from '../../src/assets/asset-loader';
+import { Mp4FrameSource, type DemuxedMp4Video } from '../../src/assets/mp4-video';
 import { assetType, hasIntrinsicDuration } from '../../src/scene/scene-graph';
 import type { EvaluatedScene } from '../../src/types/scene';
 
@@ -215,5 +216,94 @@ describe('animated assets', () => {
     await synchronizeVideoAssets(frame, assets, { playing: false, exact: true });
     await synchronizeVideoAssets(frame, assets, { playing: true });
     expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it('streams MP4 decoding without midstream flush and closes safely twice', async () => {
+    let needsKeyFrame = true;
+    let flushes = 0;
+    vi.stubGlobal(
+      'EncodedVideoChunk',
+      class {
+        constructor(init: EncodedVideoChunkInit) {
+          Object.assign(this, init);
+        }
+      }
+    );
+    vi.stubGlobal(
+      'VideoDecoder',
+      class {
+        state: CodecState = 'configured';
+        decodeQueueSize = 0;
+        static isConfigSupported(config: VideoDecoderConfig) {
+          return Promise.resolve({ supported: true, config });
+        }
+
+        constructor(private init: VideoDecoderInit) {}
+        configure() {
+          needsKeyFrame = true;
+        }
+        decode(chunk: EncodedVideoChunk) {
+          if (needsKeyFrame && chunk.type !== 'key') {
+            throw new DOMException(
+              'A key frame is required after configure() or flush()',
+              'DataError'
+            );
+          }
+          needsKeyFrame = false;
+          this.decodeQueueSize += 1;
+          queueMicrotask(() => {
+            this.init.output({ timestamp: chunk.timestamp, close() {} } as VideoFrame);
+            this.decodeQueueSize -= 1;
+          });
+        }
+        flush() {
+          flushes += 1;
+          needsKeyFrame = true;
+          return Promise.resolve();
+        }
+        reset() {
+          needsKeyFrame = true;
+        }
+        close() {
+          if (this.state === 'closed') throw new DOMException('Codec already closed');
+          this.state = 'closed';
+        }
+      }
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage() {},
+    } as unknown as CanvasRenderingContext2D);
+
+    const samples = [
+      { cts: 0, is_sync: true },
+      { cts: 10, is_sync: false },
+      { cts: 20, is_sync: false },
+      { cts: 30, is_sync: false },
+      { cts: 100, is_sync: true },
+    ].map((sample) => ({
+      ...sample,
+      timescale: 100,
+      duration: 10,
+      data: new Uint8Array([sample.cts]),
+    })) as DemuxedMp4Video['samples'];
+    const source = await Mp4FrameSource.create({
+      codec: 'avc1.64001f',
+      width: 16,
+      height: 9,
+      duration: 1,
+      samples,
+    });
+
+    try {
+      await source.renderAt(0);
+      await expect(source.renderAt(0.25)).resolves.toBeUndefined();
+      expect(flushes).toBe(0);
+      source.close();
+      expect(() => source.close()).not.toThrow();
+    } finally {
+      source.close();
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/tests/cli/local-workflow.test.ts
+++ b/tests/cli/local-workflow.test.ts
@@ -92,7 +92,7 @@ describe('local CLI workflow', () => {
     const child = spawn(
       process.execPath,
       [cli, 'dev', 'demo', '--port', String(port), '--no-open'],
-      { cwd: workspace, stdio: 'ignore' }
+      { cwd: workspace, stdio: 'ignore', env: { ...process.env, PATH: '' } }
     );
 
     try {
@@ -115,6 +115,13 @@ describe('local CLI workflow', () => {
       const bundle = await fetch(`http://127.0.0.1:${port}${script}`);
       expect(bundle.headers.get('content-type')).toContain('text/javascript');
 
+      const ffmpeg = await fetch(`http://127.0.0.1:${port}/api/exports/ffmpeg`);
+      expect(ffmpeg.status).toBe(503);
+      const unauthorizedInstall = await fetch(`http://127.0.0.1:${port}/api/exports/ffmpeg`, {
+        method: 'POST',
+      });
+      expect(unauthorizedInstall.status).toBe(403);
+
       const exportResponse = await fetch(`http://127.0.0.1:${port}/api/exports`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -124,6 +131,8 @@ describe('local CLI workflow', () => {
           fps: 1,
           duration: 1,
           totalFrames: 1,
+          quality: 'medium',
+          bitrateMbps: 5,
           hasAudio: false,
           audioStart: 0,
         }),

--- a/tests/export/exporter.test.ts
+++ b/tests/export/exporter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { canExport } from '../../src/export/exporter';
+import { canExport, ensureFfmpeg } from '../../src/export/exporter';
 
 describe('MP4 export support', () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -7,5 +7,45 @@ describe('MP4 export support', () => {
   it('uses deterministic canvas frames instead of MediaRecorder support', () => {
     vi.stubGlobal('MediaRecorder', undefined);
     expect(canExport('mp4')).toBe(true);
+  });
+
+  it('offers to install missing FFmpeg and respects cancellation', async () => {
+    const confirmInstall = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const onInstallChange = vi.fn();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(ensureFfmpeg(confirmInstall, onInstallChange)).resolves.toBe(false);
+    await expect(ensureFfmpeg(confirmInstall, onInstallChange)).resolves.toBe(true);
+    expect(onInstallChange.mock.calls).toEqual([[true], [false, true]]);
+    expect(fetch).toHaveBeenLastCalledWith('/api/exports/ffmpeg', {
+      method: 'POST',
+      headers: { 'x-motionly-action': 'install-ffmpeg' },
+    });
+  });
+
+  it('preserves export cancellation while checking FFmpeg', async () => {
+    const controller = new AbortController();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              'abort',
+              () => reject(new DOMException('Export cancelled', 'AbortError')),
+              { once: true }
+            );
+          })
+      )
+    );
+
+    const checking = ensureFfmpeg(undefined, undefined, controller.signal);
+    controller.abort();
+    await expect(checking).rejects.toMatchObject({ name: 'AbortError' });
   });
 });

--- a/tests/ui/motion-editor-components.test.ts
+++ b/tests/ui/motion-editor-components.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { mount, tick, unmount } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import MotionlyApp from '../../src/ui/MotionlyApp.svelte';
 import MotionEditor from '../../src/ui/components/MotionEditor.svelte';
 import EditorFeedback from '../../src/ui/components/motion-editor/EditorFeedback.svelte';
 import NavigationRail from '../../src/ui/components/motion-editor/NavigationRail.svelte';
@@ -145,6 +146,292 @@ describe('motion editor leaf components', () => {
 });
 
 describe('MotionEditor integration', () => {
+  it('configures and cancels an export before offering FFmpeg installation', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    const storage = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    });
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    const savePicker = vi.fn().mockResolvedValue({
+      name: 'chosen.mp4',
+      getFile: () => Promise.resolve(new File([], 'chosen.mp4')),
+      createWritable: () => Promise.resolve({ write: vi.fn(), close: vi.fn() }),
+    });
+    vi.stubGlobal('showSaveFilePicker', savePicker);
+    let finishInstall: ((response: Response) => void) | undefined;
+    const installation = new Promise<Response>((resolve) => {
+      finishInstall = resolve;
+    });
+    let ffmpegChecks = 0;
+    let firstExportSignal: AbortSignal | null = null;
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) !== '/api/exports/ffmpeg') return new Response('', { status: 404 });
+      if (init?.method === 'POST') return installation;
+      ffmpegChecks += 1;
+      if (ffmpegChecks === 1) {
+        firstExportSignal = init?.signal as AbortSignal;
+        return new Promise<Response>((_resolve, reject) => {
+          firstExportSignal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('Export cancelled', 'AbortError')),
+            { once: true }
+          );
+        });
+      }
+      return new Response('', { status: 503 });
+    });
+    vi.stubGlobal('fetch', fetch);
+    localStorage.removeItem('motionly:auto-save');
+
+    const host = target();
+    const instance = mount(MotionlyApp, { target: host });
+    await tick();
+
+    click(host.querySelector('.export-action'));
+    await tick();
+    expect(host.querySelector('.export-settings-dialog')).not.toBeNull();
+    expect(
+      Array.from(host.querySelectorAll('#export-format option')).map((option) => option.textContent)
+    ).toEqual(['MP4', 'WebM', 'GIF']);
+    expect(host.querySelector<HTMLSelectElement>('#export-fps')?.value).toBe('60');
+    expect(host.querySelector<HTMLSelectElement>('#export-resolution')?.value).toBe('1080');
+    expect(host.querySelector<HTMLSelectElement>('#export-quality')?.value).toBe('high');
+    expect(host.querySelector<HTMLSelectElement>('#export-bitrate')?.value).toBe('10');
+    expect(
+      Array.from(host.querySelectorAll('#export-quality option')).map(
+        (option) => option.textContent
+      )
+    ).toEqual(['Low', 'Medium', 'High', 'Very High']);
+    expect(
+      Array.from(host.querySelectorAll('#export-fps option')).map((option) => option.textContent)
+    ).toEqual(['24 FPS', '25 FPS', '30 FPS', '50 FPS', '60 FPS']);
+    expect(
+      Array.from(host.querySelectorAll('#export-bitrate option')).map(
+        (option) => option.textContent
+      )
+    ).toEqual(['2 Mbps', '5 Mbps', '10 Mbps', '20 Mbps', '30 Mbps', '50 Mbps', '100 Mbps']);
+    expect(savePicker).not.toHaveBeenCalled();
+
+    const fps = host.querySelector<HTMLSelectElement>('#export-fps');
+    const resolution = host.querySelector<HTMLSelectElement>('#export-resolution');
+    const quality = host.querySelector<HTMLSelectElement>('#export-quality');
+    const bitrate = host.querySelector<HTMLSelectElement>('#export-bitrate');
+    if (!fps || !resolution || !quality || !bitrate) throw new Error('Export settings missing');
+    fps.value = '30';
+    fps.dispatchEvent(new Event('change', { bubbles: true }));
+    resolution.value = '720';
+    resolution.dispatchEvent(new Event('change', { bubbles: true }));
+    quality.value = 'medium';
+    quality.dispatchEvent(new Event('change', { bubbles: true }));
+    bitrate.value = '5';
+    bitrate.dispatchEvent(new Event('change', { bubbles: true }));
+    click(
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Choose Save Location'
+      ) ?? null
+    );
+    await new Promise((resolve) => setTimeout(resolve));
+    await tick();
+    const pickerOptions = savePicker.mock.calls[0]?.[0] as { suggestedName?: string };
+    expect(pickerOptions.suggestedName).toMatch(/^untitled_\d{4}-\d{2}-\d{2}_\d{4}\.mp4$/);
+    expect(host.querySelector('.export-spinner')).not.toBeNull();
+    expect(host.querySelector('.export-progress-card')?.textContent).toContain('Exporting MP4');
+    expect(host.querySelector('.export-progress-card')?.textContent).toContain('0% complete');
+    expect(host.querySelector('.export-progress-track')?.getAttribute('aria-valuenow')).toBe('0');
+    click(
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Cancel Export'
+      ) ?? null
+    );
+    await new Promise((resolve) => setTimeout(resolve));
+    await tick();
+    expect(firstExportSignal?.aborted).toBe(true);
+    expect(host.querySelector('.export-spinner')).toBeNull();
+    expect(host.querySelector('.export-progress-card')).toBeNull();
+
+    click(host.querySelector('.export-action'));
+    await tick();
+    click(
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Choose Save Location'
+      ) ?? null
+    );
+    await new Promise((resolve) => setTimeout(resolve));
+    await tick();
+    expect(host.querySelector('.me-dialog-header')?.textContent).toContain('Install FFmpeg?');
+    click(
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Install FFmpeg'
+      ) ?? null
+    );
+    await tick();
+    expect(host.querySelector('.me-dialog-spinner')).not.toBeNull();
+    expect(host.querySelector('.me-dialog-btn.me-danger')?.textContent).toContain('Installing…');
+    expect(host.querySelector<HTMLButtonElement>('.me-dialog-btn.me-secondary')?.disabled).toBe(
+      true
+    );
+
+    finishInstall?.(new Response(null, { status: 204 }));
+    await new Promise((resolve) => setTimeout(resolve));
+    await tick();
+    expect(host.querySelector('.me-dialog')).toBeNull();
+    expect(host.querySelector('.export-spinner')).toBeNull();
+    expect(host.querySelector('.me-keyframe-toast')?.textContent).toBe('FFmpeg installed.');
+
+    await unmount(instance);
+    localStorage.removeItem('motionly:auto-save');
+  });
+
+  it('auto-saves a server-backed project before it is reopened', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+
+    let project = `canvas { size 320x180 fps 30 duration 2s background #000000 }
+text original { value "Original" center }`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) !== '/api/motion-project') return new Response('', { status: 404 });
+        if (init?.method === 'PUT') {
+          project = String(init.body);
+          return new Response(null, { status: 204 });
+        }
+        return new Response(project, {
+          headers: {
+            'content-type': 'text/plain;charset=utf-8',
+            'x-motionly-project-name': 'project.motion',
+          },
+        });
+      })
+    );
+
+    const saved = project.replace('original', 'restored').replace('Original', 'Restored');
+    let host = target();
+    let instance = mount(MotionlyApp, { target: host });
+    await new Promise((resolve) => setTimeout(resolve));
+    await tick();
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const textarea = host.querySelector<HTMLTextAreaElement>('.me-code-textarea');
+    if (!textarea) throw new Error('Source editor missing');
+    textarea.value = saved;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await unmount(instance);
+    host.remove();
+
+    host = target();
+    instance = mount(MotionlyApp, { target: host });
+    await new Promise((resolve) => setTimeout(resolve));
+    await tick();
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    expect(host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value).toBe(saved);
+
+    await unmount(instance);
+  });
+
+  it('restores the auto-saved project after remounting', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 404 })));
+    const storage = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    });
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    localStorage.removeItem('motionly:auto-save');
+
+    const saved = `canvas { size 320x180 fps 30 duration 2s background #000000 }
+text restored { value "Still here" center }`;
+    let host = target();
+    let instance = mount(MotionlyApp, { target: host });
+    await tick();
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    const textarea = host.querySelector<HTMLTextAreaElement>('.me-code-textarea');
+    if (!textarea) throw new Error('Source editor missing');
+    textarea.value = saved;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+    await unmount(instance);
+    host.remove();
+
+    host = target();
+    instance = mount(MotionlyApp, { target: host });
+    await tick();
+    click(host.querySelector('.me-source-toggle'));
+    await tick();
+    expect(host.querySelector<HTMLTextAreaElement>('.me-code-textarea')?.value).toBe(saved);
+
+    await unmount(instance);
+    localStorage.removeItem('motionly:auto-save');
+  });
+
+  it('deletes selected timeline items with Delete or Backspace', async () => {
+    class ResizeObserverStub {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('requestAnimationFrame', (_callback: FrameRequestCallback) => 1);
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => canvasContext());
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+
+    const host = target();
+    const instance = mount(MotionEditor, {
+      target: host,
+      props: {
+        code: `canvas { size 320x180 fps 30 duration 2s background #000000 }
+text title { value "Title" center }
+text subtitle { value "Subtitle" center }`,
+        onSave: () => undefined,
+      },
+    });
+    await tick();
+
+    for (const [id, key] of [
+      ['title', 'Delete'],
+      ['subtitle', 'Backspace'],
+    ] as const) {
+      const item = host.querySelector<HTMLButtonElement>(`[aria-label="Select or move ${id}"]`);
+      if (!item) throw new Error(`Timeline item ${id} missing`);
+      click(item);
+      item.focus();
+      item.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      await tick();
+      expect(host.querySelector(`[aria-label="Select or move ${id}"]`)).toBeNull();
+    }
+
+    await unmount(instance);
+  });
+
   it('deletes an imported asset from the asset sidebar', async () => {
     class ResizeObserverStub {
       observe(): void {}


### PR DESCRIPTION
## Summary

  - Fixed MP4 exports containing video assets with keyframe-safe decoding.  #57.
  - Added native save-location selection and editable timestamped filenames.  #54.
  - Added format, resolution, FPS, quality, bitrate, progress, cancellation, FFmpeg installation, and short
    success messages. #51.

  ## Testing

  - npm test -- --run --testTimeout=20000 — 496 tests passed.
  - npm run type-check
  - npx lint-staged

  ## Risk

  - MP4 export depends on local FFmpeg and OS installation permissions.
  - Higher export settings require more processing time and memory.
  - WebM availability depends on browser codec support.

  ## Checklist

  - [x] I ran npm test.
  - [x] I kept the change scoped and readable.
  - [x] I updated docs for syntax, preset, export, or public behavior changes.
  - [x] I did not mutate imported assets or add hidden renderer state.