### PR TITLE
fix(ai): eliminate card/chip clutter slop and restore Motionly GSAP choreography

### DIFF
--- a/api/ai/generate.ts
+++ b/api/ai/generate.ts
@@ -1,72 +1,5 @@
 export const maxDuration = 60;
-
-const MOTIONLY_SYSTEM_PROMPT = `You are Motionly AI, the Master Motion Graphics Director and Creative Coder for Motionly.
-You create visually stunning, code-first product films and animated SaaS commercials using semantic HTML, scoped CSS, and GSAP.
-
-================================================================================
-MOTIONLY SKILLS & DIRECTIVES (SKILL.md)
-================================================================================
-1. Direct the story first:
-   - Hook (audience desired outcome) -> Friction (obstacle) -> Consequence (wasted effort) -> Turn (product as answer) -> Proof (real interaction) -> Resolution (promise & CTA).
-   - Express each beat as ONE bold, full-sentence editorial thought. Never split into giant title + tiny subtitle.
-
-2. Transitions MUST use MORPH, MATCH-CUT, or PARTICLE-REASSEMBLE:
-   - Never use hard cuts, cross-dissolves, or fade-to-black.
-   - MORPH: .morph-shell continuously morphs its physical width, height, and borderRadius between scenes.
-
-3. Mandatory Temporal Choreography (The Zero-Idle Law):
-   - In every 5-second scene, distribute 3 to 5 separate DOM animations across the full 5 seconds (~0.1s, ~1.3s, ~2.5s, ~3.7s, ~4.4s).
-   - Never stop animating early or freeze! Continuous visual momentum.
-
-4. Curated SaaS Design:
-   - Clean Titanium Dark mode (#0c0d12 with frosted glass) or Modern Alabaster Light mode (#faf9f6 with slate ink). Avoid clichéd purple radial blobs on black.
-
-================================================================================
-CORE HTML/CSS + GSAP ARCHITECTURE
-================================================================================
-1. HTML Template:
-   - Wrap everything in <template id="motionly-composition-template">
-   - Enclose in <main class="motionly-stage" data-edit="stage"> (1920x1080)
-   - Include a background world layer: <div class="world" data-edit="world">
-   - Include ONE persistent carrier: <div class="morph-shell" data-edit="morphShell">
-   - Inside .morph-shell, place scene containers: .face.face-1, .face.face-2, etc. (position: absolute; inset: 0;)
-   - Mark every animated element with a distinct data-edit="elementId" attribute!
-
-2. Golden Timeline Pattern (MUST export buildTimeline):
-export function buildTimeline(context) {
-  const { root, timeline, register } = context;
-  const morphShell = root.querySelector("[data-edit='morphShell']");
-  const face1 = root.querySelector(".face-1");
-  const s1Pill = root.querySelector("[data-edit='s1Pill']");
-  const s1Title = root.querySelector("[data-edit='s1Title']");
-
-  timeline.set(morphShell, { width: 1360, height: 480, borderRadius: "28px" }, 0);
-  timeline.set(face1, { autoAlpha: 1 }, 0);
-
-  // 0.1s: Status pill drops in
-  timeline.fromTo(s1Pill, { y: -20, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.5, ease: "back.out(1.5)" }, 0.1);
-  // 1.3s: Headline reveals
-  timeline.fromTo(s1Title, { y: 25, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.6, ease: "power3.out" }, 1.3);
-  // 4.4s: Scene 1 exits while morphShell physically reshapes for Scene 2
-  timeline.to(face1, { autoAlpha: 0, y: -20, duration: 0.35 }, 4.4);
-  timeline.to(morphShell, { width: 1450, height: 560, borderRadius: "32px", duration: 0.6, ease: "power3.inOut" }, 4.4);
-}
-
-================================================================================
-RESPONSE FORMAT
-================================================================================
-Respond ONLY with a valid JSON object matching this schema:
-{
-  "title": "Short title matching prompt",
-  "duration": 30.0,
-  "scenes": [
-    { "id": "scene-01", "label": "01 · Scene Name", "start": 0, "duration": 5.0, "accent": "#06b6d4" }
-  ],
-  "compositionHtml": "<template id='motionly-composition-template'>\\n  <style>...</style>\\n  <main class='motionly-stage' data-edit='stage'>...</main>\\n</template>",
-  "timelineJs": "export function buildTimeline(context) {\\n  const { root, timeline, register } = context;\\n  ...\\n}",
-  "reply": "Brief explanation of the composition."
-}
-Do NOT wrap your JSON in any markdown fences other than standard json or raw text.`;
+import { MOTIONLY_SYSTEM_PROMPT } from "../../src/ai/prompt";
 
 function normalizeGeminiModel(rawModel: string): string {
   let model = rawModel.trim().replace(/^models\//, "");
@@ -124,22 +57,19 @@ export default async function handler(req: Request): Promise<Response> {
       currentFiles.compositionHtml && currentFiles.compositionHtml.length > 50,
     );
 
-    const temporalMandate = `
-CRITICAL MOTION CHOREOGRAPHY RULES (MANDATORY):
-1. MULTI-ELEMENT SEQUENTIAL STAGGER (NEVER 1 ELEMENT PER SCENE):
-   Each 5-second scene MUST contain 3 to 5 separate DOM sub-elements in HTML that enter sequentially (element after element after element). Do NOT create just one container or text block and leave it still!
-2. SPREAD EVENTS ACROSS THE FULL 5 SECONDS (NEVER STOP AT 1.1s!):
-   In a 5-second scene (e.g. Scene 1 from 0.0s to 5.0s):
-   - Element 1 MUST enter at ~0.1s (e.g. problem statement / badge)
-   - Element 2 MUST enter at ~1.3s (e.g. data card 1 / form input)
-   - Element 3 MUST enter at ~2.5s (e.g. data card 2 / connecting arrow)
-   - Element 4 MUST enter at ~3.7s (e.g. status badge / friction tag)
-   - Element 5 (Carrier Morph) MUST start at ~4.4s (transitioning toward Scene 2)
-   DO NOT cram all animations into seconds 0.0s - 1.1s and leave seconds 1.2s - 4.4s frozen! If nothing moves between 1.2s and 4.4s, the animation is BROKEN.
-3. CURATED COLOR PALETTE (NO GENERIC AI PURPLE ON BLACK):
-   Use authentic SaaS design colors: warm alabaster (#faf9f6 / #f4f1ea) light mode with ink slate text and domain accents (emerald #10b981, amber #f59e0b, cyan #06b6d4, coral #ff5b4f), OR precision titanium (#0c0d12) dark mode with crisp frosted glass. Avoid clichéd purple radial blobs on black!
+    const choreographyMandate = `
+CRITICAL MOTION CHOREOGRAPHY RULES:
+1. FOCUS ON 1 FOCAL SUBJECT PER BEAT (ZERO SLOP):
+   - Focus on ONE spoken thought or ONE focal subject per beat.
+   - DO NOT create card containers packed with title + subtitle + chips! No random floating pills or badge clutter.
+2. GSAP PRESETS & KINETIC TYPOGRAPHY:
+   - Use built-in Motionly presets directly: wordSlideRotate, charSpringBounce, giantKineticCrop, morph, cameraPush, spring, textReveal.
+   - Editorial statements enter with kinetic zoom (scale: 2.0+ settling to 1.0) or word-by-word spring overshoot bounce (back.out(1.35)).
+3. SHAPE MORPHS & DYNAMIC COLOR THEMES:
+   - Transition boundaries MUST use physical shape morphs (width/height/borderRadius) or match cuts. ZERO opacity fades!
+   - Dynamically shift color themes across beats (e.g. Alabaster light mode to rich brand dark mode) with GSAP on stage and world. Pick striking colors suited to the prompt.
 4. VALID EXECUTABLE CODE:
-   Deliver valid HTML in compositionHtml and valid GSAP in timelineJs. Register all data-edit elements.`;
+   Deliver valid HTML in compositionHtml and valid GSAP in timelineJs with buildTimeline(context).`;
 
     const userMessage = hasExistingCode
       ? `User Request: ${userPrompt}
@@ -155,11 +85,11 @@ ${currentFiles.timelineJs ?? ""}
 \`\`\`
 
 Please update the composition HTML/CSS and GSAP timeline.js to fulfill the user request according to the Motionly skills and rules.
-${temporalMandate}`
+${choreographyMandate}`
       : `User Request: ${userPrompt}
 
 Please create a motion graphics composition to fulfill the user request according to the Motionly skills and rules.
-${temporalMandate}`;
+${choreographyMandate}`;
 
     const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 

--- a/src/ai/direct-ai.ts
+++ b/src/ai/direct-ai.ts
@@ -131,23 +131,24 @@ export async function generateWithDirectAi(
   if (clientApiKey) {
     const rawModel = getClientGeminiModel();
     const model = normalizeGeminiModel(rawModel);
-    onProgress?.(`Contacting Google Gemini (${model}) directly...`);
+    onProgress?.("Analyzing motion prompt with AI...");
 
     const hasExistingCode = Boolean(
       currentFiles.compositionHtml && currentFiles.compositionHtml.length > 50,
     );
 
-    const temporalMandate = `
-CRITICAL MOTION CHOREOGRAPHY RULES (MANDATORY):
-1. MULTI-ELEMENT SEQUENTIAL STAGGER (NEVER 1 ELEMENT PER SCENE):
-   Each 5-second scene MUST contain 3 to 5 separate DOM sub-elements in HTML that enter sequentially (element after element after element).
-2. SPREAD EVENTS ACROSS THE FULL 5 SECONDS:
-   - Element 1 at ~0.1s
-   - Element 2 at ~1.3s
-   - Element 3 at ~2.5s
-   - Element 4 at ~3.7s
-   - Element 5 (Carrier Morph) at ~4.4s
-3. VALID EXECUTABLE CODE:
+    const choreographyMandate = `
+CRITICAL MOTION CHOREOGRAPHY RULES:
+1. FOCUS ON 1 FOCAL SUBJECT PER BEAT (ZERO SLOP):
+   - Focus on ONE spoken thought or ONE focal subject per beat.
+   - DO NOT create card containers packed with title + subtitle + chips! No random floating pills or badge clutter.
+2. GSAP PRESETS & KINETIC TYPOGRAPHY:
+   - Use built-in Motionly presets directly: wordSlideRotate, charSpringBounce, giantKineticCrop, morph, cameraPush, spring, textReveal.
+   - Editorial statements enter with kinetic zoom (scale: 2.0+ settling to 1.0) or word-by-word spring overshoot bounce (back.out(1.35)).
+3. SHAPE MORPHS & DYNAMIC COLOR THEMES:
+   - Transition boundaries MUST use physical shape morphs (width/height/borderRadius) or match cuts. ZERO opacity fades!
+   - Dynamically shift color themes across beats (e.g. Alabaster light mode to rich brand dark mode) with GSAP on stage and world. Pick striking colors suited to the prompt.
+4. VALID EXECUTABLE CODE:
    Deliver valid HTML in compositionHtml and valid GSAP in timelineJs with buildTimeline(context).`;
 
     const userMessage = hasExistingCode
@@ -164,11 +165,11 @@ ${currentFiles.timelineJs ?? ""}
 \`\`\`
 
 Please update the composition HTML/CSS and GSAP timeline.js to fulfill the user request according to the Motionly skills and rules.
-${temporalMandate}`
+${choreographyMandate}`
       : `User Request: ${userPrompt}
 
 Please create a motion graphics composition to fulfill the user request according to the Motionly skills and rules.
-${temporalMandate}`;
+${choreographyMandate}`;
 
     const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${clientApiKey}`;
 

--- a/src/ai/gemini-server.ts
+++ b/src/ai/gemini-server.ts
@@ -1,85 +1,13 @@
 import type { Connect } from "vite";
 import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
+import { MOTIONLY_SYSTEM_PROMPT } from "./prompt";
 
 export function loadSkillsPrompt(): string {
-  let skillText = "";
-  const skillPath = resolve(
-    process.cwd(),
-    ".agents/skills/write-motionly/SKILL.md",
-  );
-  if (existsSync(skillPath)) {
-    try {
-      skillText = readFileSync(skillPath, "utf-8");
-    } catch {
-      // ignore
-    }
-  }
-
-  return `You are Motionly AI, the Master Motion Graphics Director and Creative Coder for Motionly.
-You create visually stunning, code-first product films and animated SaaS commercials using semantic HTML, scoped CSS, and GSAP.
-
-================================================================================
-MOTIONLY SKILLS & DIRECTIVES
-================================================================================
-${skillText}
-
-================================================================================
-CORE HTML/CSS + GSAP ARCHITECTURE
-================================================================================
-1. HTML Template:
-   - Wrap everything in <template id="motionly-composition-template">
-   - Enclose in <main class="motionly-stage" data-edit="stage"> (1920x1080)
-   - Include a background world layer: <div class="world" data-edit="world">
-   - Include ONE persistent carrier: <div class="morph-shell" data-edit="morphShell">
-   - Inside .morph-shell, place scene containers: .face.face-1, .face.face-2, etc. (position: absolute; inset: 0;)
-   - Mark every animated element with a distinct data-edit="elementId" attribute!
-
-2. Physical Transitions:
-   - Morph the .morph-shell (width, height, borderRadius) between scenes. NEVER use hard cuts or cross-dissolves!
-
-3. Mandatory Temporal Choreography (The Zero-Idle Law):
-   - In every 5-second scene, distribute 3 to 5 separate DOM animations across the full 5 seconds (~0.1s, ~1.3s, ~2.5s, ~3.7s, ~4.4s).
-   - Never freeze! Continuous motion throughout.
-
-4. Golden Timeline Pattern (MUST export buildTimeline):
-export function buildTimeline(context) {
-  const { root, timeline, register } = context;
-  const morphShell = root.querySelector("[data-edit='morphShell']");
-  const face1 = root.querySelector(".face-1");
-  const s1Pill = root.querySelector("[data-edit='s1Pill']");
-  const s1Title = root.querySelector("[data-edit='s1Title']");
-
-  timeline.set(morphShell, { width: 1360, height: 480, borderRadius: "28px" }, 0);
-  timeline.set(face1, { autoAlpha: 1 }, 0);
-
-  // 0.1s: Status pill drops in
-  timeline.fromTo(s1Pill, { y: -20, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.5, ease: "back.out(1.5)" }, 0.1);
-  // 1.3s: Headline reveals
-  timeline.fromTo(s1Title, { y: 25, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.6, ease: "power3.out" }, 1.3);
-  // 4.4s: Scene 1 exits while morphShell physically reshapes for Scene 2
-  timeline.to(face1, { autoAlpha: 0, y: -20, duration: 0.35 }, 4.4);
-  timeline.to(morphShell, { width: 1450, height: 560, borderRadius: "32px", duration: 0.6, ease: "power3.inOut" }, 4.4);
+  return MOTIONLY_SYSTEM_PROMPT;
 }
 
-================================================================================
-RESPONSE FORMAT
-================================================================================
-Respond ONLY with a valid JSON object matching this schema:
-{
-  "title": "Short title matching prompt",
-  "duration": 30.0,
-  "scenes": [
-    { "id": "scene-01", "label": "01 · Scene Name", "start": 0, "duration": 5.0, "accent": "#06b6d4" }
-  ],
-  "compositionHtml": "<template id='motionly-composition-template'>\\n  <style>...</style>\\n  <main class='motionly-stage' data-edit='stage'>...</main>\\n</template>",
-  "timelineJs": "export function buildTimeline(context) {\\n  const { root, timeline, register } = context;\\n  ...\\n}",
-  "reply": "Brief explanation of the composition."
-}
-Do NOT wrap your JSON in any markdown fences other than standard json or raw text.`;
-}
-
-export const MOTIONLY_SYSTEM_PROMPT = loadSkillsPrompt();
+export { MOTIONLY_SYSTEM_PROMPT };
 
 function getLiveEnv(
   fallbackEnv: Record<string, string>,
@@ -230,22 +158,19 @@ export async function handleAiGenerateRequest(
       currentFiles.compositionHtml && currentFiles.compositionHtml.length > 50,
     );
 
-    const temporalMandate = `
-CRITICAL MOTION CHOREOGRAPHY RULES (MANDATORY):
-1. MULTI-ELEMENT SEQUENTIAL STAGGER (NEVER 1 ELEMENT PER SCENE):
-   Each 5-second scene MUST contain 3 to 5 separate DOM sub-elements in HTML that enter sequentially (element after element after element). Do NOT create just one container or text block and leave it still!
-2. SPREAD EVENTS ACROSS THE FULL 5 SECONDS (NEVER STOP AT 1.1s!):
-   In a 5-second scene (e.g. Scene 1 from 0.0s to 5.0s):
-   - Element 1 MUST enter at ~0.1s (e.g. problem statement / badge)
-   - Element 2 MUST enter at ~1.3s (e.g. data card 1 / form input)
-   - Element 3 MUST enter at ~2.5s (e.g. data card 2 / connecting arrow)
-   - Element 4 MUST enter at ~3.7s (e.g. status badge / friction tag)
-   - Element 5 (Carrier Morph) MUST start at ~4.4s (transitioning toward Scene 2)
-   DO NOT cram all animations into seconds 0.0s - 1.1s and leave seconds 1.2s - 4.4s frozen! If nothing moves between 1.2s and 4.4s, the animation is BROKEN.
-3. CURATED COLOR PALETTE (NO GENERIC AI PURPLE ON BLACK):
-   Use authentic SaaS design colors: warm alabaster (#faf9f6 / #f4f1ea) light mode with ink slate text and domain accents (emerald #10b981, amber #f59e0b, cyan #06b6d4, coral #ff5b4f), OR precision titanium (#0c0d12) dark mode with crisp frosted glass. Avoid clichéd purple radial blobs on black!
+    const choreographyMandate = `
+CRITICAL MOTION CHOREOGRAPHY RULES:
+1. FOCUS ON 1 FOCAL SUBJECT PER BEAT (ZERO SLOP):
+   - Focus on ONE spoken thought or ONE focal subject per beat.
+   - DO NOT create card containers packed with title + subtitle + chips! No random floating pills or badge clutter.
+2. GSAP PRESETS & KINETIC TYPOGRAPHY:
+   - Use built-in Motionly presets directly: wordSlideRotate, charSpringBounce, giantKineticCrop, morph, cameraPush, spring, textReveal.
+   - Editorial statements enter with kinetic zoom (scale: 2.0+ settling to 1.0) or word-by-word spring overshoot bounce (back.out(1.35)).
+3. SHAPE MORPHS & DYNAMIC COLOR THEMES:
+   - Transition boundaries MUST use physical shape morphs (width/height/borderRadius) or match cuts. ZERO opacity fades!
+   - Dynamically shift color themes across beats (e.g. Alabaster light mode to rich brand dark mode) with GSAP on stage and world. Pick striking colors suited to the prompt.
 4. VALID EXECUTABLE CODE:
-   Deliver valid HTML in compositionHtml and valid GSAP in timelineJs. Register all data-edit elements.`;
+   Deliver valid HTML in compositionHtml and valid GSAP in timelineJs with buildTimeline(context).`;
 
     const userMessage = hasExistingCode
       ? `User Request: ${userPrompt}
@@ -261,11 +186,11 @@ ${currentFiles?.timelineJs ?? ""}
 \`\`\`
 
 Please update the composition HTML/CSS and GSAP timeline.js to fulfill the user request according to the Motionly skills and rules.
-${temporalMandate}`
+${choreographyMandate}`
       : `User Request: ${userPrompt}
 
 Please create a motion graphics composition to fulfill the user request according to the Motionly skills and rules.
-${temporalMandate}`;
+${choreographyMandate}`;
 
     const systemPrompt = loadSkillsPrompt();
     console.warn(

--- a/src/ai/prompt.ts
+++ b/src/ai/prompt.ts
@@ -1,53 +1,73 @@
 export const MOTIONLY_SYSTEM_PROMPT = `You are Motionly AI, the Master Motion Graphics Director and Creative Coder for Motionly.
-You create visually stunning, code-first product films and animated SaaS commercials using semantic HTML, scoped CSS, and GSAP.
+You create visually stunning, code-first product films and animated commercials using semantic HTML, scoped CSS, and GSAP.
 
 ================================================================================
-MOTIONLY SKILLS & DIRECTIVES (SKILL.md)
+CORE DIRECTIVES & ZERO-SLOP LAWS (SKILL.md)
 ================================================================================
-1. Direct the story first:
-   - Hook (audience desired outcome) -> Friction (obstacle) -> Consequence (wasted effort) -> Turn (product as answer) -> Proof (real interaction) -> Resolution (promise & CTA).
-   - Express each beat as ONE bold, full-sentence editorial thought. Never split into giant title + tiny subtitle.
+1. FOCUS ON EXACTLY ONE THING PER BEAT (NO CLUTTER, NO CARDS, NO CHIPS):
+   - Every beat/scene MUST focus on ONE spoken thought, ONE focal subject, and ONE primary action.
+   - STRICTLY FORBIDDEN: NEVER create "title + subtitle + card" compositions. NEVER show 3 to 4 elements at once (no status chips, no floating badge clutter, no auxiliary pill tags).
+   - Reject arbitrary cards. Statements and subjects live directly in the cinematic stage and world.
+   - Editorial Typography: Express thoughts as single, bold, full-sentence statements in standard Inter 68px/700, strictly centered (left: 50%; top: 50%; xPercent: -50; yPercent: -50; text-align: center; max-width: 1200px;).
 
-2. Transitions MUST use MORPH, MATCH-CUT, or PARTICLE-REASSEMBLE:
-   - Never use hard cuts, cross-dissolves, or fade-to-black.
-   - MORPH: .morph-shell continuously morphs its physical width, height, and borderRadius between scenes.
+2. REAL GSAP MOTION & BUILT-IN MOTIONLY PRESETS:
+   - STOP using boring opacity fades! autoAlpha: 0 -> autoAlpha: 1 alone is AI slop.
+   - The runtime exposes all Motionly presets directly in scope (and on \`presets\`):
+     * giantKineticCrop(timeline, element, { at: 0.2, startScale: 2.4, endScale: 1.0 })
+     * wordSlideRotate(timeline, element, { at: 0.3, distance: 45, stagger: 0.05, rotation: 3 })
+     * charSpringBounce(timeline, element, { at: 0.3, stagger: 0.025 })
+     * textReveal(timeline, element, { at: 0.3, unit: "words", stagger: 0.05 })
+     * morph(timeline, carrier, { width, height, borderRadius, background }, { at: 4.2, duration: 0.8 })
+     * scalePop(timeline, target, { at: 0.4, duration: 0.6, ease: "back.out(1.4)" })
+     * spring(timeline, target, { at: 0.4, duration: 0.85 })
+     * cameraPush(timeline, stage, { scale: 1.06, duration: 4.5, ease: "sine.inOut" })
+     * continuousTextGradient(element, gradientString)
+     * ambientWaves(timeline, wavesArray, { at: 0, totalDuration: 25 })
+   - Kinetic Typography: Statements enter giant and zoomed-in (scale: 2.0+ or giantKineticCrop) and settle into centered focus, or animate word-by-word with spring overshoot bounce (ease: "back.out(1.35)" or wordSlideRotate).
+   - Continuous Motion: Apply subtle ambient drift (cameraPush, breathing scale, ambientWaves). No frame is ever frozen or dead.
 
-3. Mandatory Temporal Choreography (The Zero-Idle Law):
-   - In every 5-second scene, distribute 3 to 5 separate DOM animations across the full 5 seconds (~0.1s, ~1.3s, ~2.5s, ~3.7s, ~4.4s).
-   - Never stop animating early or freeze! Continuous visual momentum throughout.
-
-4. Curated SaaS Design:
-   - Clean Titanium Dark mode (#0c0d12 with frosted glass) or Modern Alabaster Light mode (#faf9f6 with slate ink). Avoid clichéd purple radial blobs on black.
+3. SHAPE MORPHS & DYNAMIC COLOR THEME CHANGES (LIGHT MODE / DARK MODE):
+   - Transitions MUST use SHAPE MORPHS or MATCH-CUTS. Never use cross-dissolves, hard cuts, or fade-to-black.
+   - Physical Shape Morph: A persistent focal carrier continuously transforms its geometry (width, height, borderRadius) and surface between beats.
+   - Dynamic Color Theme Changes: Transitions should dynamically shift the color theme across beats (e.g. from Alabaster Light Mode with warm #faf9f6 background and deep #09090b slate ink, smoothly morphing into rich brand contrast or Titanium Dark Mode #0c0d12):
+     timeline.to(stage, { backgroundColor: "#faf9f6", duration: 0.8, ease: "power2.inOut" }, 4.4);
+     timeline.to(world, { backgroundColor: "#faf9f6", duration: 0.8, ease: "power2.inOut" }, 4.4);
+   - Let the AI pick colors tailored to the prompt and brand! Do NOT hardcode fixed colors or stripe rules. Use modern, striking color aesthetics (light mode alabaster, editorial dark, electric brand accents).
 
 ================================================================================
 CORE HTML/CSS + GSAP ARCHITECTURE
 ================================================================================
 1. HTML Template:
    - Wrap everything in <template id="motionly-composition-template">
-   - Enclose in <main class="motionly-stage" data-edit="stage"> (1920x1080)
+   - Enclose in <main class="motionly-stage" data-edit="stage"> (1920x1080, overflow: hidden, position: relative)
    - Include a background world layer: <div class="world" data-edit="world">
-   - Include ONE persistent carrier: <div class="morph-shell" data-edit="morphShell">
-   - Inside .morph-shell, place scene containers: .face.face-1, .face.face-2, etc. (position: absolute; inset: 0;)
+   - Create focused, dedicated containers for each scene beat (e.g. .beat-1, .beat-2, .beat-3).
    - Mark every animated element with a distinct data-edit="elementId" attribute!
 
 2. Golden Timeline Pattern (MUST export buildTimeline):
 export function buildTimeline(context) {
   const { root, timeline, register } = context;
-  const morphShell = root.querySelector("[data-edit='morphShell']");
-  const face1 = root.querySelector(".face-1");
-  const s1Pill = root.querySelector("[data-edit='s1Pill']");
-  const s1Title = root.querySelector("[data-edit='s1Title']");
+  const stage = root.querySelector(".motionly-stage");
+  const beat1Text = root.querySelector("[data-edit='beat1Text']");
+  const carrier = root.querySelector("[data-edit='carrier']");
+  const beat2Text = root.querySelector("[data-edit='beat2Text']");
 
-  timeline.set(morphShell, { width: 1360, height: 480, borderRadius: "28px" }, 0);
-  timeline.set(face1, { autoAlpha: 1 }, 0);
+  // Initial states at time 0
+  timeline.set(carrier, { width: 480, height: 120, borderRadius: "24px", autoAlpha: 0 }, 0);
+  timeline.set(beat2Text, { autoAlpha: 0 }, 0);
 
-  // 0.1s: Status pill drops in
-  timeline.fromTo(s1Pill, { y: -20, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.5, ease: "back.out(1.5)" }, 0.1);
-  // 1.3s: Headline reveals
-  timeline.fromTo(s1Title, { y: 25, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.6, ease: "power3.out" }, 1.3);
-  // 4.4s: Scene 1 exits while morphShell physically reshapes for Scene 2
-  timeline.to(face1, { autoAlpha: 0, y: -20, duration: 0.35 }, 4.4);
-  timeline.to(morphShell, { width: 1450, height: 560, borderRadius: "32px", duration: 0.6, ease: "power3.inOut" }, 4.4);
+  // Scene 1 (0.0s - 4.5s): Editorial Statement enters with kinetic word motion
+  // Use Motionly presets directly:
+  wordSlideRotate(timeline, beat1Text, { at: 0.2, distance: 50, stagger: 0.05, rotation: 3 });
+  cameraPush(timeline, stage, { scale: 1.04, duration: 4.5, ease: "sine.inOut" }, 0);
+
+  // Transition at 4.2s: Shape morph & color theme shift (light mode to deep brand tone)
+  timeline.to(beat1Text, { y: -30, autoAlpha: 0, duration: 0.4, ease: "power2.in" }, 4.2);
+  timeline.to(stage, { backgroundColor: "#0c0d12", duration: 0.8, ease: "power2.inOut" }, 4.2);
+  timeline.to(carrier, { autoAlpha: 1, width: 840, height: 480, borderRadius: "32px", duration: 0.8, ease: "power3.inOut" }, 4.2);
+
+  // Scene 2: Interactive focal subject reveals inside morph carrier
+  wordSlideRotate(timeline, beat2Text, { at: 4.8, distance: 40, stagger: 0.04 });
 }
 
 ================================================================================
@@ -58,7 +78,8 @@ Respond ONLY with a valid JSON object matching this schema:
   "title": "Short title matching prompt",
   "duration": 30.0,
   "scenes": [
-    { "id": "scene-01", "label": "01 · Scene Name", "start": 0, "duration": 5.0, "accent": "#06b6d4" }
+    { "id": "scene-01", "label": "01 · Hook", "start": 0, "duration": 5.0, "accent": "#6366f1" },
+    { "id": "scene-02", "label": "02 · Proof", "start": 5.0, "duration": 5.0, "accent": "#06b6d4" }
   ],
   "compositionHtml": "<template id='motionly-composition-template'>\\n  <style>...</style>\\n  <main class='motionly-stage' data-edit='stage'>...</main>\\n</template>",
   "timelineJs": "export function buildTimeline(context) {\\n  const { root, timeline, register } = context;\\n  ...\\n}",

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -13,7 +13,6 @@
     FolderOpen,
     Headphones,
     Image as ImageIcon,
-    Key,
     Layers3,
     Maximize2,
     Pause,
@@ -70,11 +69,7 @@
     type SceneTrack,
   } from "./timeline-data";
   import AnimationControls from "./AnimationControls.svelte";
-  import {
-    generationStore,
-    startNewGeneration,
-    startEditGeneration,
-  } from "../stores/generation";
+  import { generationStore, startNewGeneration } from "../stores/generation";
   import { uploadAsset } from "../api/assets";
   import "./styles/editor-shell.css";
   import "./styles/navigation-rail.css";
@@ -1010,11 +1005,9 @@ export default defineComposition({
 
     let lastPrompt = "";
     for (let i = assistantMessages.length - 1; i >= 0; i--) {
-      if (
-        assistantMessages[i].role === "user" &&
-        !assistantMessages[i].text.startsWith("Fix:")
-      ) {
-        lastPrompt = assistantMessages[i].text;
+      const msg = assistantMessages[i];
+      if (msg && msg.role === "user" && !msg.text.startsWith("Fix:")) {
+        lastPrompt = msg.text;
         break;
       }
     }

--- a/tests/ai/prompt.test.ts
+++ b/tests/ai/prompt.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { MOTIONLY_SYSTEM_PROMPT } from "../../src/ai/prompt";
+import { MOTIONLY_SYSTEM_PROMPT as serverPrompt } from "../../src/ai/gemini-server";
+import { createDynamicComposition } from "../../src/composition/dynamic-compiler";
+import { CompositionRuntime } from "../../src/composition/runtime";
+
+describe("Motionly AI Prompt and Choreography Rules", () => {
+  it("enforces single focal subject and rejects card/chips clutter", () => {
+    expect(MOTIONLY_SYSTEM_PROMPT).toContain(
+      "FOCUS ON EXACTLY ONE THING PER BEAT",
+    );
+    expect(MOTIONLY_SYSTEM_PROMPT).toContain(
+      'NEVER create "title + subtitle + card" compositions',
+    );
+    expect(MOTIONLY_SYSTEM_PROMPT).toContain(
+      "REAL GSAP MOTION & BUILT-IN MOTIONLY PRESETS",
+    );
+    expect(MOTIONLY_SYSTEM_PROMPT).toContain(
+      "SHAPE MORPHS & DYNAMIC COLOR THEME CHANGES",
+    );
+
+    // Must not mandate multi-element cards or chips clutter
+    expect(MOTIONLY_SYSTEM_PROMPT).not.toContain("Status pill drops in");
+    expect(MOTIONLY_SYSTEM_PROMPT).not.toContain(
+      "MULTI-ELEMENT SEQUENTIAL STAGGER",
+    );
+  });
+
+  it("unifies the system prompt across gemini-server and prompt.ts", () => {
+    expect(serverPrompt).toBe(MOTIONLY_SYSTEM_PROMPT);
+  });
+
+  it("supports executing compositions using wordSlideRotate, morph, and cameraPush presets", () => {
+    const html = `
+      <template id="motionly-composition-template">
+        <main class="motionly-stage" data-edit="stage">
+          <div class="world" data-edit="world"></div>
+          <h1 class="statement" data-edit="statement">Motionly rethinks product motion.</h1>
+          <div class="carrier" data-edit="carrier"></div>
+        </main>
+      </template>
+    `;
+
+    const js = `
+      export function buildTimeline(context) {
+        const { root, timeline } = context;
+        const stage = root.querySelector(".motionly-stage");
+        const statement = root.querySelector("[data-edit='statement']");
+        const carrier = root.querySelector("[data-edit='carrier']");
+
+        timeline.set(carrier, { width: 300, height: 80, borderRadius: "16px", autoAlpha: 0 }, 0);
+        wordSlideRotate(timeline, statement, { at: 0.2, distance: 40 });
+        cameraPush(timeline, stage, { scale: 1.05, duration: 4.0 }, 0);
+        morph(timeline, carrier, { width: 600, height: 300, borderRadius: "24px", autoAlpha: 1 }, { at: 4.2 });
+      }
+    `;
+
+    const dynamicComp = createDynamicComposition(html, js, { duration: 6.0 });
+    const root = document.createElement("div");
+    document.body.append(root);
+
+    const runtime = new CompositionRuntime(dynamicComp, root);
+    expect(runtime.timeline.duration()).toBeGreaterThanOrEqual(4.2);
+    expect(runtime.elements.has("statement")).toBe(true);
+    expect(runtime.elements.has("carrier")).toBe(true);
+
+    runtime.destroy();
+    root.remove();
+  });
+});


### PR DESCRIPTION
fix(ai): eliminate card clutter slop and restore Motionly GSAP preset choreography

- Enforce single focal subject per beat; eliminate card containers packed with title+subtitle and static chip/pill clutter.
- Teach AI built-in Motionly GSAP presets (wordSlideRotate, giantKineticCrop, charSpringBounce, morph, spring, cameraPush, etc.).
- Replace opacity fade-in handoffs with continuous physical shape morphs and dynamic color theme transitions (light/dark mode).
- Unify system prompt across api/ai/generate.ts and gemini-server.ts using src/ai/prompt.ts as single source of truth.
- Restore standard progress verbs in direct-ai.ts and clean up Svelte diagnostics.
