### PR TITLE
feat: add editor tooltips

### DIFF
--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -1141,16 +1141,16 @@ export default defineComposition({
         ><Save size={17} /><span>Save</span></button
       >
       <button
-        class="btn"
-        title="Export Current Frame as PNG"
+        class="btn me-tooltip"
+        data-tooltip="Export Current Frame as PNG"
         on:click={exportFrame}
         disabled={exporting}
       >
         <ImageIcon size={16} /><span>PNG</span>
       </button>
       <button
-        class="btn export-action"
-        title="Render and Download 1080p Full Video"
+        class="btn export-action me-tooltip"
+        data-tooltip="Render and Download 1080p Full Video"
         on:click={exportFullVideo}
         disabled={exporting}
       >
@@ -1233,7 +1233,8 @@ export default defineComposition({
                 >
               </div>
               <button
-                class="me-import-header-btn"
+                class="me-import-header-btn me-tooltip"
+                data-tooltip="Import media"
                 on:click={() => mediaInput.click()}
                 ><Upload size={14} /> Import</button
               >
@@ -1359,7 +1360,8 @@ export default defineComposition({
               <div class="me-asset-grid project-asset-grid">
                 <div class="me-asset-card-wrap">
                   <button
-                    class="me-asset-card"
+                    class="me-asset-card me-tooltip"
+                    data-tooltip="Select logo.svg"
                     on:click={() => (selectedId = "brand-token")}
                   >
                     <span class="me-asset-thumbnail project-asset-thumbnail"
@@ -1374,7 +1376,8 @@ export default defineComposition({
                 </div>
                 <div class="me-asset-card-wrap">
                   <button
-                    class="me-asset-card"
+                    class="me-asset-card me-tooltip"
+                    data-tooltip="Select github.svg"
                     on:click={() =>
                       showNotice("github.svg is ready in public/.")}
                   >
@@ -1584,18 +1587,22 @@ export default defineComposition({
               {/if}
               <div class="me-property-row">
                 <label class="me-property-group"
-                  ><span class="me-property-label">X</span><input
+                  ><span class="me-property-label">X</span>
+                  <input
                     class="me-number-input"
                     aria-label="X position"
+                    title="Horizontal position"
                     type="number"
                     value={currentOverride().x ?? 0}
                     on:input={(event) => setNumber("x", event)}
                   /></label
                 >
                 <label class="me-property-group"
-                  ><span class="me-property-label">Y</span><input
+                  ><span class="me-property-label">Y</span>
+                  <input
                     class="me-number-input"
                     aria-label="Y position"
+                    title="Vertical position"
                     type="number"
                     value={currentOverride().y ?? 0}
                     on:input={(event) => setNumber("y", event)}
@@ -1604,9 +1611,11 @@ export default defineComposition({
               </div>
               <div class="me-property-row">
                 <label class="me-property-group"
-                  ><span class="me-property-label">Scale</span><input
+                  ><span class="me-property-label">Scale</span>
+                  <input
                     class="me-number-input"
                     aria-label="Scale"
+                    title="Scale selected element"
                     type="number"
                     step="0.05"
                     value={currentOverride().scale ?? 1}
@@ -1614,9 +1623,11 @@ export default defineComposition({
                   /></label
                 >
                 <label class="me-property-group"
-                  ><span class="me-property-label">Rotation</span><input
+                  ><span class="me-property-label">Rotation</span>
+                  <input
                     class="me-number-input"
                     aria-label="Rotation"
+                    title="Rotate selected element"
                     type="number"
                     value={currentOverride().rotation ?? 0}
                     on:input={(event) => setNumber("rotation", event)}
@@ -1630,6 +1641,7 @@ export default defineComposition({
                 <input
                   id="property-opacity"
                   class="me-custom-slider"
+                  title="Adjust opacity"
                   type="range"
                   min="0"
                   max="1"
@@ -1805,9 +1817,11 @@ export default defineComposition({
           <div class="me-timeline-context">
             {#if timelineMode === "scene"}
               <button
-                class="me-timeline-back"
+                class="me-timeline-back me-tooltip"
                 on:click={showProjectTimeline}
-                aria-label="Back to all scenes"><ArrowLeft size={14} /></button
+                aria-label="Back to all scenes"
+                data-tooltip="Back to all scenes"
+                ><ArrowLeft size={14} /></button
               >
               <Layers3 size={14} /><span>{selectedScene()?.label}</span>
             {:else}
@@ -1818,14 +1832,16 @@ export default defineComposition({
           </div>
           <div class="me-playback-controls">
             <button
-              class="me-control-btn"
+              class="me-control-btn me-tooltip"
               aria-label="Restart"
+              data-tooltip="Restart"
               on:click={() => runtime?.restart()}
               ><RefreshCcw size={15} /></button
             >
             <button
-              class="me-control-btn me-play-btn"
+              class="me-control-btn me-play-btn me-tooltip"
               aria-label={snapshot.playing ? "Pause" : "Play"}
+              data-tooltip={snapshot.playing ? "Pause" : "Play"}
               on:click={togglePlayback}
               >{#if snapshot.playing}<Pause size={16} />{:else}<Play
                   size={16}

--- a/src/ui/styles/editor-theme.css
+++ b/src/ui/styles/editor-theme.css
@@ -1024,6 +1024,40 @@
   opacity: 1;
   transform: translate(-50%, 0);
 }
+
+.code-editor-scope .me-tooltip {
+  position: relative;
+}
+
+.code-editor-scope .me-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  z-index: 90;
+  padding: 5px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  background: #29292d;
+  color: #f1f1f3;
+  font-size: 9.5px;
+  font-weight: 550;
+  line-height: 1;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 3px);
+  transition:
+    opacity 0.12s ease,
+    transform 0.12s ease;
+}
+
+.code-editor-scope .me-tooltip:hover::after,
+.code-editor-scope .me-tooltip:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .code-editor-scope .me-rotation-property {
   padding-top: 2px;
 }


### PR DESCRIPTION
## Summary

- Add helpful tooltips to editor controls for issue #19.
- Add tooltips to export, import, timeline playback, transform and asset controls.
- Add reusable tooltip styling for editor buttons.

## Testing

- ‌‌‌‌‌`npm.cmd run test:run` - 21 tests passed.
- `npm.cmd run build` - build succeeded.
- Manually tested tooltips in the editor.

## Visual Evidence

Tooltip displayed when hovering over the Play control in the editor:
<img width="1553" height="844" alt="image" src="https://github.com/user-attachments/assets/8f6b09b5-427d-4dbf-afe2-2640d580e4e3" />

## Risk

- Low. Changes are limited to tooltip attributes and tooltip styling.

## Checklist

- [ x ] I ran `npm test`.
- [ x ] I kept the change scoped and readable.
- [   ] I updated docs for composition, preset, export, or public behavior changes.
- [ x ] I did not mutate imported assets or add hidden renderer state.
